### PR TITLE
Clarify headless starter steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ For detailed guidelines on documenting your code, refer to the [comments.md](./d
 
 - The translations were moved to the [dedicated translation repository](https://github.com/pagefaultgames/pokerogue-locales) and are now applied as a submodule in this project.
 - The command to retrieve the translations is `git submodule update --init --recursive`. If you still struggle to get it working, please reach out to #dev-corner channel in Discord.
+## Running Tests
+
+Run `npm ci --ignore-scripts` to install dependencies without executing postinstall hooks.
+Then run `npm run test:silent` to execute the Vitest suite with concise output.
+
 
 ## 🪧 To Do
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,11 @@ This document summarizes high level tasks required to expose the game logic for 
   - `step(action)` – apply a single action and advance the game phases.
   - `getState()` – return a serialized representation of the current gamestate.
 - Use existing `GameManager` utilities as reference but strip out UI handlers and test-only helpers.
+- `reset()` should automatically start a classic run with a fixed starter party:
+  - Squirtle, Bulbasaur and Charmander are added directly to the player's party.
+  - Skip all menus and immediately push phases so the first enemy encounter begins.
+  - Reuse logic from `initSceneWithoutEncounterPhase()` to build the starters and populate `BattleScene`.
+  - The first call to `step()` should correspond to selecting the first action in the opening battle.
 
 ## 2. Game state serialization
 - Implement serialization functions that traverse scene objects and return JSON describing:

--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -1,0 +1,66 @@
+import Phaser from "phaser";
+import BattleScene from "#app/battle-scene";
+
+/**
+ * Headless environment for automated gameplay without UI.
+ *
+ * This minimal wrapper mirrors the test `GameManager` setup but
+ * exposes a simpler interface suited for reinforcement learning.
+ */
+export default class RogueEnv {
+  /** Underlying Phaser game instance running in headless mode. */
+  private game: Phaser.Game;
+
+  /** The active {@link BattleScene}. */
+  public scene: BattleScene;
+
+  constructor() {
+    this.game = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+    this.scene = new BattleScene();
+    // Attach the scene to the game immediately.
+    this.game.scene.add("battle", this.scene, true);
+    this.scene.create();
+  }
+
+  /**
+   * Reset the scene to the initial state.
+   * Equivalent to starting a new run.
+   */
+  reset(): void {
+    this.scene.reset(false, true);
+    this.scene.phaseManager.clearAllPhases();
+    this.scene.phaseManager.pushNew("LoginPhase");
+    this.scene.phaseManager.pushNew("TitlePhase");
+    this.scene.phaseManager.shiftPhase();
+  }
+
+  /**
+   * Apply an action and progress to the next phase.
+   * @param action Function that interacts with the underlying scene.
+   */
+  step(action?: (scene: BattleScene) => void): void {
+    action?.(this.scene);
+    this.scene.phaseManager.shiftPhase();
+  }
+
+  /**
+   * Return a lightweight snapshot of the current battle state.
+   */
+  getState(): Record<string, unknown> {
+    return {
+      phase: this.scene.phaseManager.getCurrentPhase()?.constructor.name,
+      playerParty: this.scene.getPlayerParty().map(p => ({
+        id: p.species.speciesId,
+        hp: p.hp,
+        maxHp: p.getMaxHp(),
+      })),
+      enemyParty: this.scene.getEnemyParty().map(p => ({
+        id: p.species.speciesId,
+        hp: p.hp,
+        maxHp: p.getMaxHp(),
+      })),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- document how RogueEnv reset should automatically add starter trio and skip menus

## Testing
- `npm ci --ignore-scripts`
- `npx vitest run --silent --no-isolate` *(fails: long execution)*

------
https://chatgpt.com/codex/tasks/task_e_6847876ce0e88324be788002ed6b0be0