### PR TITLE
Add setup instructions for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Instructions for Agents
+
+This repository requires a specific environment before running any tests or commands.
+
+## Dependencies
+- `git`
+- `curl`
+- `nvm` (version 0.39.7 or newer)
+- `node` 22.14.0
+- `npm`
+
+## Setup
+Before running other commands, execute the setup script:
+
+```bash
+bash setup.sh
+```
+
+This installs Node.js via nvm, updates npm, initializes the translation submodule and installs project dependencies.
+
+## Verification
+After running the setup script, execute the verification script to confirm the environment is ready:
+
+```bash
+bash verify-setup.sh
+```
+
+Do not run other project commands until the verification script exits successfully.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+# Install Node.js 22.14.0 using nvm
+export NVM_DIR="$HOME/.nvm"
+if [ ! -d "$NVM_DIR" ]; then
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+# shellcheck source=/dev/null
+source "$NVM_DIR/nvm.sh"
+# install and use exact node version from .nvmrc
+nvm install 22.14.0
+nvm use 22.14.0
+
+# update npm to latest
+npm install -g npm
+
+# fetch translation submodule
+if [ -f .gitmodules ]; then
+  git submodule update --init --recursive
+fi
+
+# install project dependencies
+npm ci

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+EXPECTED_NODE_VERSION="v22.14.0"
+ACTUAL_NODE_VERSION="$(node --version)"
+if [ "$ACTUAL_NODE_VERSION" != "$EXPECTED_NODE_VERSION" ]; then
+  echo "Expected Node $EXPECTED_NODE_VERSION but found $ACTUAL_NODE_VERSION"
+  exit 1
+fi
+
+npm --version >/dev/null
+
+if [ ! -d "public/locales" ]; then
+  echo "Translations submodule missing"
+  exit 1
+fi
+
+if [ ! -d "node_modules" ]; then
+  echo "Dependencies not installed"
+  exit 1
+fi
+
+echo "Environment verified"


### PR DESCRIPTION
## Summary
- document dependencies in a root `AGENTS.md`
- instruct agents to run `setup.sh` then verify with `verify-setup.sh`
- include new `verify-setup.sh` script for environment checks

## Testing
- `bash setup.sh` *(interrupted post-install)*
- `bash verify-setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847b094e5808324a5bf8fa38175e14b