### PR TITLE
Add environment scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Instructions for Agents
+
+This repository requires a specific environment before running any tests or commands.
+
+## Dependencies
+- `git`
+- `curl`
+- `nvm` (version 0.39.7 or newer)
+- `node` 22.14.0
+- `npm`
+
+## Setup
+Before running other commands, execute the setup script:
+
+```bash
+bash setup.sh
+```
+
+This installs Node.js via nvm, updates npm, initializes the translation submodule and installs project dependencies.
+
+## Verification
+After running the setup script, execute the verification script to confirm the environment is ready:
+
+```bash
+bash verify-setup.sh
+```
+
+Do not run other project commands until the verification script exits successfully.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+# Install Node.js 22.14.0 using nvm
+export NVM_DIR="$HOME/.nvm"
+if [ ! -d "$NVM_DIR" ]; then
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+# shellcheck source=/dev/null
+source "$NVM_DIR/nvm.sh"
+# install and use node version from .nvmrc
+NODE_VERSION="$(cat .nvmrc)"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+# update npm to latest
+npm install -g npm
+
+# fetch translation submodule
+if [ -f .gitmodules ]; then
+  git submodule update --init --recursive
+fi
+
+# install project dependencies without running postinstall hooks
+npm ci --ignore-scripts

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1159,8 +1159,8 @@ export default class BattleScene extends SceneBase {
 
     this.modifiers = [];
     this.enemyModifiers = [];
-    this.modifierBar.removeAll(true);
-    this.enemyModifierBar.removeAll(true);
+    this.modifierBar?.removeAll(true);
+    this.enemyModifierBar?.removeAll(true);
 
     for (const p of this.getPlayerParty()) {
       p.destroy();

--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -1,8 +1,9 @@
 import Phaser from "phaser";
 import BattleScene from "#app/battle-scene";
-import { LoadingScene } from "#app/loading-scene";
 import { Command } from "#enums/command";
 import serializeState, { type SerializedState } from "#app/utils/serialize";
+import GameWrapper from "#test/testUtils/gameWrapper";
+import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
 
 export enum RogueAction {
   /** Use the first move in the active Pokémon's moveset. */
@@ -25,6 +26,9 @@ export default class RogueEnv {
   /** Underlying Phaser game instance running in headless mode. */
   private game: Phaser.Game;
 
+  /** Helper wrapper for injecting Phaser mocks. */
+  private wrapper: GameWrapper;
+
   /** The active {@link BattleScene}. */
   public scene: BattleScene;
 
@@ -33,9 +37,16 @@ export default class RogueEnv {
       type: Phaser.HEADLESS,
     });
     this.scene = new BattleScene();
-    // Attach the scenes to the game immediately.
-    this.game.scene.add(LoadingScene.KEY, new LoadingScene(), true);
-    this.game.scene.add("battle", this.scene, true);
+    this.wrapper = new GameWrapper(this.game, true);
+    this.wrapper.setScene(this.scene);
+    const originalPush = this.scene.phaseManager.pushNew.bind(this.scene.phaseManager);
+    this.scene.phaseManager.pushNew = (phase: string, ...args: any[]) => {
+      if (phase === "LoginPhase" || phase === "TitlePhase") {
+        return;
+      }
+      return originalPush(phase as any, ...(args as any));
+    };
+    this.scene.phaseManager.clearAllPhases();
   }
 
   /**
@@ -44,9 +55,11 @@ export default class RogueEnv {
    */
   reset(): void {
     this.scene.reset(false, true);
+    this.scene.enableTutorials = false;
+    initSceneWithoutEncounterPhase(this.scene);
+    this.scene.currentBattle.incrementTurn();
     this.scene.phaseManager.clearAllPhases();
-    this.scene.phaseManager.pushNew("LoginPhase");
-    this.scene.phaseManager.pushNew("TitlePhase");
+    this.scene.phaseManager.pushNew("TurnInitPhase");
     this.scene.phaseManager.shiftPhase();
   }
 

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+EXPECTED_NODE_VERSION="$(cat .nvmrc)"
+ACTUAL_NODE_VERSION="$(node --version)"
+if [ "$ACTUAL_NODE_VERSION" != "$EXPECTED_NODE_VERSION" ]; then
+  echo "Expected Node $EXPECTED_NODE_VERSION but found $ACTUAL_NODE_VERSION"
+  exit 1
+fi
+
+npm --version >/dev/null
+
+if [ ! -d "public/locales" ]; then
+  echo "Translations submodule missing"
+  exit 1
+fi
+
+if [ ! -d "node_modules" ]; then
+  echo "Dependencies not installed"
+  exit 1
+fi
+
+echo "Environment verified"


### PR DESCRIPTION
## Summary
- document environment setup steps in root AGENTS.md
- add setup.sh using Node version from .nvmrc
- add verify-setup.sh to ensure node, npm, submodule, and dependencies
- fix RogueEnv reset to avoid UI phases and initialize starter state
- guard optional UI elements in BattleScene.reset

## Testing
- `bash verify-setup.sh`
- `npx vitest run test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6847b094e5808324a5bf8fa38175e14b