### PR TITLE
Implement transition logging

### DIFF
--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -2,6 +2,9 @@ import Phaser from "phaser";
 import BattleScene from "#app/battle-scene";
 import { Command } from "#enums/command";
 import serializeState, { type SerializedState } from "#app/utils/serialize";
+import TransitionLogger, {
+  type TransitionRecord,
+} from "#app/transition-logger";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
 
@@ -28,6 +31,9 @@ export default class RogueEnv {
 
   /** Helper wrapper for injecting Phaser mocks. */
   private wrapper: GameWrapper;
+
+  /** Optional logger for transition data. */
+  public logger?: TransitionLogger;
 
   /** The active {@link BattleScene}. */
   public scene: BattleScene;
@@ -70,7 +76,12 @@ export default class RogueEnv {
    * appropriate in‑game command. A custom function may also be passed to
    * manipulate the underlying {@link BattleScene} directly.
    */
-  step(action?: RogueAction | ((scene: BattleScene) => void)): void {
+  step(
+    action?: RogueAction | ((scene: BattleScene) => void),
+    reward = 0,
+    done = false,
+  ): void {
+    const prevState = this.getState();
     if (typeof action === "number") {
       const phase: any = this.scene.phaseManager.getCurrentPhase();
       if (phase?.handleCommand) {
@@ -80,6 +91,17 @@ export default class RogueEnv {
       action(this.scene);
     }
     this.scene.phaseManager.shiftPhase();
+    const nextState = this.getState();
+    if (this.logger) {
+      const record: TransitionRecord = {
+        state: prevState,
+        action: typeof action === "number" ? action : -1,
+        reward,
+        nextState,
+        done,
+      };
+      this.logger.log(record);
+    }
   }
 
   /**

--- a/src/transition-logger.ts
+++ b/src/transition-logger.ts
@@ -1,0 +1,30 @@
+import { type SerializedState } from "#app/utils/serialize";
+import type { RogueAction } from "#app/rogue-env";
+
+export interface TransitionRecord {
+  state: SerializedState;
+  action: number;
+  reward: number;
+  nextState: SerializedState;
+  done: boolean;
+}
+
+export default class TransitionLogger {
+  private records: TransitionRecord[] = [];
+
+  log(record: TransitionRecord): void {
+    this.records.push(record);
+  }
+
+  clear(): void {
+    this.records = [];
+  }
+
+  getRecords(): TransitionRecord[] {
+    return this.records;
+  }
+
+  toJSON(): string {
+    return JSON.stringify(this.records);
+  }
+}

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import RogueEnv, { RogueAction } from "#app/rogue-env";
+import TransitionLogger from "#app/transition-logger";
 
 describe("rogue-env serialization", () => {
   it("should return serialized state after reset", () => {
@@ -16,5 +17,20 @@ describe("rogue-env serialization", () => {
     env.step(RogueAction.FIGHT_1);
     const nextState = env.getState();
     expect(nextState.turn).toBeGreaterThanOrEqual(state.turn);
+  });
+});
+
+describe("rogue-env logging", () => {
+  it("should log transitions when logger attached", () => {
+    const env = new RogueEnv();
+    env.logger = new TransitionLogger();
+    env.reset();
+    const start = env.getState();
+    env.step(RogueAction.FIGHT_1, 1, false);
+    const records = env.logger.getRecords();
+    expect(records.length).toBe(1);
+    expect(records[0].state).toEqual(start);
+    expect(records[0].action).toBe(RogueAction.FIGHT_1);
+    expect(records[0].nextState).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- create a `TransitionLogger` utility
- record transitions from `RogueEnv.step`
- test transition logging

## Testing
- `bash setup.sh`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68486500a578832495d1a3e07a3bca51