### PR TITLE
Extend RogueEnv state serialization

### DIFF
--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,11 +1,16 @@
 import type BattleScene from "#app/battle-scene";
 import type Pokemon from "#app/field/pokemon";
+import { StatusEffect } from "#enums/status-effect";
 
 export interface SerializedPokemon {
   species: number;
   level: number;
   hp: number;
   maxHp: number;
+  /** Numeric status effect identifier. */
+  status: number;
+  /** Held item modifier ids. */
+  items: string[];
   moves: { id: number; pp: number; maxPp: number }[];
 }
 
@@ -22,6 +27,8 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
     level: p.level,
     hp: p.hp,
     maxHp: p.getMaxHp(),
+    status: p.status?.effect ?? StatusEffect.NONE,
+    items: p.getHeldItems().map(i => i.type.id),
     moves: p.getMoveset().map(m => ({ id: m.moveId, pp: m.getMovePp() - m.ppUsed, maxPp: m.getMovePp() })),
   };
 }

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -13,6 +13,9 @@ describe("rogue-env serialization", () => {
     expect(Array.isArray(state.enemyParty)).toBe(true);
     expect(state.playerParty[0]).toHaveProperty("species");
     expect(state.playerParty[0]).toHaveProperty("moves");
+    expect(state.playerParty[0]).toHaveProperty("status");
+    expect(state.playerParty[0]).toHaveProperty("items");
+    expect(Array.isArray(state.playerParty[0].items)).toBe(true);
 
     env.step(RogueAction.FIGHT_1);
     const nextState = env.getState();


### PR DESCRIPTION
## Summary
- include status effect and held items when serializing Pokemon
- test additional serialized fields

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6848736569e48324acccbae27653917d