### PR TITLE
Improve headless state serialization

### DIFF
--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -11,6 +11,10 @@ export interface SerializedPokemon {
   status: number;
   /** Held item modifier ids. */
   items: string[];
+  /** Array of seven in-battle stat stage values. */
+  statStages: number[];
+  /** Whether this Pokémon is currently active on the field. */
+  active: boolean;
   moves: { id: number; pp: number; maxPp: number }[];
 }
 
@@ -19,6 +23,18 @@ export interface SerializedState {
   turn: number;
   playerParty: SerializedPokemon[];
   enemyParty: SerializedPokemon[];
+  /** Indexes of the player's currently active Pokémon. */
+  playerActive: number[];
+  /** Indexes of the enemy's currently active Pokémon. */
+  enemyActive: number[];
+  /** Current weather effect in the arena. */
+  weather: number;
+  /** Current terrain effect in the arena. */
+  terrain: number;
+  /** Current wave number. */
+  wave: number;
+  /** Player's available money. */
+  money: number;
 }
 
 function serializePokemon(p: Pokemon): SerializedPokemon {
@@ -29,6 +45,8 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
     maxHp: p.getMaxHp(),
     status: p.status?.effect ?? StatusEffect.NONE,
     items: p.getHeldItems().map(i => i.type.id),
+    statStages: p.getStatStages(),
+    active: p.isActive(true),
     moves: p.getMoveset().map(m => ({ id: m.moveId, pp: m.getMovePp() - m.ppUsed, maxPp: m.getMovePp() })),
   };
 }
@@ -39,5 +57,11 @@ export default function serializeState(scene: BattleScene): SerializedState {
     turn: scene.currentBattle?.turn ?? 0,
     playerParty: scene.getPlayerParty().map(serializePokemon),
     enemyParty: scene.getEnemyParty().map(serializePokemon),
+    playerActive: scene.getPlayerField().map(p => scene.getPlayerParty().indexOf(p)),
+    enemyActive: scene.getEnemyField().map(p => scene.getEnemyParty().indexOf(p)),
+    weather: scene.arena.weather?.weatherType ?? 0,
+    terrain: scene.arena.terrain?.terrainType ?? 0,
+    wave: scene.currentBattle?.waveIndex ?? 0,
+    money: scene.money ?? 0,
   };
 }

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -16,6 +16,12 @@ describe("rogue-env serialization", () => {
     expect(state.playerParty[0]).toHaveProperty("status");
     expect(state.playerParty[0]).toHaveProperty("items");
     expect(Array.isArray(state.playerParty[0].items)).toBe(true);
+    expect(state).toHaveProperty("weather");
+    expect(state).toHaveProperty("terrain");
+    expect(state).toHaveProperty("playerActive");
+    expect(state).toHaveProperty("enemyActive");
+    expect(Array.isArray(state.playerActive)).toBe(true);
+    expect(Array.isArray(state.enemyActive)).toBe(true);
 
     env.step(RogueAction.FIGHT_1);
     const nextState = env.getState();


### PR DESCRIPTION
## Summary
- expand the data captured by `serializeState`
- include active Pokémon, stat stages, arena effects and money
- extend `rogue-env` test coverage for new fields

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684876445c848324bf4d31864edb3960