### PR TITLE
Improve rogue-env action output

### DIFF
--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import BattleScene from "#app/battle-scene";
 import { Command } from "#enums/command";
+import { CommandPhase } from "#app/phases/command-phase";
 import { randomString } from "#app/utils/common";
 import serializeState, { type SerializedState } from "#app/utils/serialize";
 import type TransitionLogger from "#app/transition-logger";
@@ -122,9 +123,41 @@ export default class RogueEnv {
   }
 
   /**
+   * Determine which {@link RogueAction | actions} are currently valid.
+   */
+  getAvailableActions(): RogueAction[] {
+    const phase = this.scene.phaseManager.getCurrentPhase();
+    const actions: RogueAction[] = [];
+    if (phase instanceof CommandPhase) {
+      const pokemon = phase.getPokemon();
+      const moves = pokemon.getMoveset();
+      for (let i = 0; i < Math.min(4, moves.length); i++) {
+        if (pokemon.trySelectMove(i)) {
+          actions.push(RogueAction.FIGHT_1 + i);
+        }
+      }
+      if (!pokemon.isTrapped()) {
+        actions.push(RogueAction.RUN);
+        const party = this.scene.getPlayerParty();
+        for (let i = 0; i < Math.min(3, party.length); i++) {
+          const p = party[i];
+          if (p.hp > 0 && !p.isActive(true)) {
+            actions.push((RogueAction.SWITCH_1 + i) as RogueAction);
+          }
+        }
+      }
+    }
+    return actions;
+  }
+
+  /**
    * Return a lightweight snapshot of the current battle state.
    */
-  getState(): SerializedState {
-    return serializeState(this.scene);
+  getState(): SerializedState & { availableActions: RogueAction[] } {
+    const state = serializeState(this.scene) as SerializedState & {
+      availableActions: RogueAction[];
+    };
+    state.availableActions = this.getAvailableActions();
+    return state;
   }
 }

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -35,6 +35,8 @@ describe("rogue-env serialization", () => {
     expect(state).toHaveProperty("arenaTags");
     expect(Array.isArray(state.arenaTags)).toBe(true);
     expect(state.shopOptions).toBeUndefined();
+    expect(Array.isArray(state.availableActions)).toBe(true);
+    expect(state.availableActions).toEqual(env.getAvailableActions());
 
     env.step(RogueAction.FIGHT_1);
     const nextState = env.getState();


### PR DESCRIPTION
## Summary
- expose `getAvailableActions` in `rogue-env`
- include available actions in state serialization
- test that the available actions are returned

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68488ae6c1c88324a848c5d062b4de33