### PR TITLE
Add log loading to TransitionLogger

### DIFF
--- a/src/transition-logger.ts
+++ b/src/transition-logger.ts
@@ -1,5 +1,6 @@
-import { type SerializedState } from "#app/utils/serialize";
-import type { RogueAction } from "#app/rogue-env";
+import type { SerializedState } from "#app/utils/serialize";
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
 
 export interface TransitionRecord {
   state: SerializedState;
@@ -26,5 +27,22 @@ export default class TransitionLogger {
 
   toJSON(): string {
     return JSON.stringify(this.records);
+  }
+
+  /**
+   * Write the current log to a file in JSON format.
+   */
+  async saveToFile(path: string): Promise<void> {
+    const file = resolve(path);
+    await fs.writeFile(file, this.toJSON(), "utf8");
+  }
+
+  /**
+   * Load transition records from a JSON file, replacing existing records.
+   */
+  async loadFromFile(path: string): Promise<void> {
+    const file = resolve(path);
+    const text = await fs.readFile(file, "utf8");
+    this.records = JSON.parse(text) as TransitionRecord[];
   }
 }

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import RogueEnv, { RogueAction } from "#app/rogue-env";
 import TransitionLogger from "#app/transition-logger";
 
@@ -56,6 +59,35 @@ describe("rogue-env logging", () => {
     expect(records[0].state).toEqual(start);
     expect(records[0].action).toBe(RogueAction.FIGHT_1);
     expect(records[0].nextState).toBeDefined();
+  });
+
+  it("should write logs to a file", async () => {
+    const env = new RogueEnv();
+    env.logger = new TransitionLogger();
+    env.reset();
+    env.step(RogueAction.FIGHT_1, 1, false);
+
+    const file = join(tmpdir(), `transitions-${Date.now()}.json`);
+    await env.logger!.saveToFile(file);
+    const contents = await fs.readFile(file, "utf8");
+    expect(contents).toBe(env.logger!.toJSON());
+    await fs.unlink(file);
+  });
+
+  it("should load logs from a file", async () => {
+    const env = new RogueEnv();
+    env.logger = new TransitionLogger();
+    env.reset();
+    env.step(RogueAction.FIGHT_1, 1, false);
+
+    const file = join(tmpdir(), `transitions-${Date.now()}.json`);
+    await env.logger.saveToFile(file);
+
+    const logger2 = new TransitionLogger();
+    await logger2.loadFromFile(file);
+    expect(logger2.getRecords()).toEqual(env.logger.getRecords());
+
+    await fs.unlink(file);
   });
 });
 


### PR DESCRIPTION
## Summary
- implement `loadFromFile` so TransitionLogger can read saved logs
- test the new loading method in `rogue-env.test.ts`

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68489e7e57748324b33dc46be5ec02b0