### PR TITLE
Add RogueEnv demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ For detailed guidelines on documenting your code, refer to the [comments.md](./d
 Run `npm ci --ignore-scripts` to install dependencies without executing postinstall hooks.
 Then run `npm run test:silent` to execute the Vitest suite with concise output. This repository however is a fork that only needs to use the tests listed within the AGENTS.md.
 
+## Headless Environment Demo
+
+Run the demo script to confirm headless battles progress correctly:
+
+```bash
+bash setup.sh
+source ~/.nvm/nvm.sh
+nvm use 22.14.0
+npm run env:demo -- 3 demo-log.json
+```
+
+The optional first argument specifies how many `step()` calls to run (defaults to 2). If a path is provided as the second argument, the transition log is written there; otherwise it prints to STDOUT.
+
 
 ## 🪧 To Do
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "lefthook": "^1.11.5",
         "msw": "^2.7.3",
         "phaser3spectorjs": "^0.0.8",
-        "rollup": "^4.40.1",
+        "tsx": "^4.19.4",
         "typedoc": "^0.28.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.28.0",
@@ -7251,6 +7251,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "postinstall": "npx lefthook install && npx lefthook run post-merge",
     "update-version:patch": "npm version patch --force --no-git-tag-version",
     "update-version:minor": "npm version minor --force --no-git-tag-version",
-    "update-locales:remote": "git submodule update --progress --init --recursive --force --remote"
+    "update-locales:remote": "git submodule update --progress --init --recursive --force --remote",
+    "env:demo": "npx tsx scripts/rogue-env-demo.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
@@ -45,6 +46,7 @@
     "lefthook": "^1.11.5",
     "msw": "^2.7.3",
     "phaser3spectorjs": "^0.0.8",
+    "tsx": "^4.19.4",
     "typedoc": "^0.28.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.28.0",

--- a/scripts/rogue-env-demo.ts
+++ b/scripts/rogue-env-demo.ts
@@ -1,0 +1,27 @@
+import RogueEnv, { RogueAction } from "#app/rogue-env";
+import TransitionLogger from "#app/transition-logger";
+
+const steps = parseInt(process.argv[2] ?? "2", 10);
+const output = process.argv[3];
+
+const env = new RogueEnv("demo-seed");
+const logger = new TransitionLogger();
+env.logger = logger;
+
+env.reset();
+for (let i = 0; i < steps; i++) {
+  const actions = env.getAvailableActions();
+  const action = actions.includes(RogueAction.FIGHT_1)
+    ? RogueAction.FIGHT_1
+    : actions[0];
+  env.step(action);
+}
+
+const json = logger.toJSON();
+if (output) {
+  await logger.saveToFile(output);
+  console.log(`Log written to ${output}`);
+} else {
+  console.log(json);
+}
+

--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -109,6 +109,13 @@ export default class RogueEnv {
       action(this.scene);
     }
     this.scene.phaseManager.shiftPhase();
+    let phase = this.scene.phaseManager.getCurrentPhase();
+    let safety = 0;
+    while (phase && !(phase instanceof CommandPhase) && safety < 100) {
+      this.scene.phaseManager.shiftPhase();
+      phase = this.scene.phaseManager.getCurrentPhase();
+      safety++;
+    }
     const nextState = this.getState();
     if (this.logger) {
       const record: TransitionRecord = {

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -105,3 +105,17 @@ describe("rogue-env seeding", () => {
     expect(second).toEqual(first);
   });
 });
+
+describe("rogue-env progression", () => {
+  it("should advance to the next command phase when stepping", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const start = env.getState();
+    expect(start.phase).toBe("CommandPhase");
+
+    env.step(RogueAction.FIGHT_1);
+    const next = env.getState();
+    expect(next.phase).toBe("CommandPhase");
+    expect(next.turn).toBeGreaterThan(start.turn);
+  });
+});


### PR DESCRIPTION
## Summary
- add `env:demo` npm script using tsx
- implement `rogue-env-demo.ts` to log a few steps of headless gameplay
- document how to run the demo in the README

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6848a47fd6a88324a3a8cc69315f0035