### PR TITLE
Enable headless mode to skip UI elements

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -517,104 +517,106 @@ export default class BattleScene extends SceneBase {
     this.modifiers = [];
     this.enemyModifiers = [];
 
-    this.modifierBar = new ModifierBar();
-    this.modifierBar.setName("modifier-bar");
-    this.add.existing(this.modifierBar);
-    uiContainer.add(this.modifierBar);
+    if (!headless) {
+      this.modifierBar = new ModifierBar();
+      this.modifierBar.setName("modifier-bar");
+      this.add.existing(this.modifierBar);
+      uiContainer.add(this.modifierBar);
 
-    this.enemyModifierBar = new ModifierBar(true);
-    this.enemyModifierBar.setName("enemy-modifier-bar");
-    this.add.existing(this.enemyModifierBar);
-    uiContainer.add(this.enemyModifierBar);
+      this.enemyModifierBar = new ModifierBar(true);
+      this.enemyModifierBar.setName("enemy-modifier-bar");
+      this.add.existing(this.enemyModifierBar);
+      uiContainer.add(this.enemyModifierBar);
 
-    this.charSprite = new CharSprite();
-    this.charSprite.setName("sprite-char");
-    this.charSprite.setup();
+      this.charSprite = new CharSprite();
+      this.charSprite.setName("sprite-char");
+      this.charSprite.setup();
 
-    this.fieldUI.add(this.charSprite);
+      this.fieldUI.add(this.charSprite);
 
-    this.pbTray = new PokeballTray(true);
-    this.pbTray.setName("pb-tray");
-    this.pbTray.setup();
+      this.pbTray = new PokeballTray(true);
+      this.pbTray.setName("pb-tray");
+      this.pbTray.setup();
 
-    this.pbTrayEnemy = new PokeballTray(false);
-    this.pbTrayEnemy.setName("enemy-pb-tray");
-    this.pbTrayEnemy.setup();
+      this.pbTrayEnemy = new PokeballTray(false);
+      this.pbTrayEnemy.setName("enemy-pb-tray");
+      this.pbTrayEnemy.setup();
 
-    this.fieldUI.add(this.pbTray);
-    this.fieldUI.add(this.pbTrayEnemy);
+      this.fieldUI.add(this.pbTray);
+      this.fieldUI.add(this.pbTrayEnemy);
 
-    this.abilityBar = new AbilityBar();
-    this.abilityBar.setName("ability-bar");
-    this.abilityBar.setup();
-    this.fieldUI.add(this.abilityBar);
+      this.abilityBar = new AbilityBar();
+      this.abilityBar.setName("ability-bar");
+      this.abilityBar.setup();
+      this.fieldUI.add(this.abilityBar);
 
-    this.partyExpBar = new PartyExpBar();
-    this.partyExpBar.setName("party-exp-bar");
-    this.partyExpBar.setup();
-    this.fieldUI.add(this.partyExpBar);
+      this.partyExpBar = new PartyExpBar();
+      this.partyExpBar.setName("party-exp-bar");
+      this.partyExpBar.setup();
+      this.fieldUI.add(this.partyExpBar);
 
-    this.candyBar = new CandyBar();
-    this.candyBar.setName("candy-bar");
-    this.candyBar.setup();
-    this.fieldUI.add(this.candyBar);
+      this.candyBar = new CandyBar();
+      this.candyBar.setName("candy-bar");
+      this.candyBar.setup();
+      this.fieldUI.add(this.candyBar);
 
-    this.biomeWaveText = addTextObject(
-      this.game.canvas.width / 6 - 2,
-      0,
-      startingWave.toString(),
-      TextStyle.BATTLE_INFO,
-    );
-    this.biomeWaveText.setName("text-biome-wave");
-    this.biomeWaveText.setOrigin(1, 0.5);
-    this.fieldUI.add(this.biomeWaveText);
+      this.biomeWaveText = addTextObject(
+        this.game.canvas.width / 6 - 2,
+        0,
+        startingWave.toString(),
+        TextStyle.BATTLE_INFO,
+      );
+      this.biomeWaveText.setName("text-biome-wave");
+      this.biomeWaveText.setOrigin(1, 0.5);
+      this.fieldUI.add(this.biomeWaveText);
 
-    this.moneyText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.MONEY);
-    this.moneyText.setName("text-money");
-    this.moneyText.setOrigin(1, 0.5);
-    this.fieldUI.add(this.moneyText);
+      this.moneyText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.MONEY);
+      this.moneyText.setName("text-money");
+      this.moneyText.setOrigin(1, 0.5);
+      this.fieldUI.add(this.moneyText);
 
-    this.scoreText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
-    this.scoreText.setName("text-score");
-    this.scoreText.setOrigin(1, 0.5);
-    this.fieldUI.add(this.scoreText);
+      this.scoreText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
+      this.scoreText.setName("text-score");
+      this.scoreText.setOrigin(1, 0.5);
+      this.fieldUI.add(this.scoreText);
 
-    this.luckText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
-    this.luckText.setName("text-luck");
-    this.luckText.setOrigin(1, 0.5);
-    this.luckText.setVisible(false);
-    this.fieldUI.add(this.luckText);
+      this.luckText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
+      this.luckText.setName("text-luck");
+      this.luckText.setOrigin(1, 0.5);
+      this.luckText.setVisible(false);
+      this.fieldUI.add(this.luckText);
 
-    this.luckLabelText = addTextObject(
-      this.game.canvas.width / 6 - 2,
-      0,
-      i18next.t("common:luckIndicator"),
-      TextStyle.PARTY,
-      { fontSize: "54px" },
-    );
-    this.luckLabelText.setName("text-luck-label");
-    this.luckLabelText.setOrigin(1, 0.5);
-    this.luckLabelText.setVisible(false);
-    this.fieldUI.add(this.luckLabelText);
+      this.luckLabelText = addTextObject(
+        this.game.canvas.width / 6 - 2,
+        0,
+        i18next.t("common:luckIndicator"),
+        TextStyle.PARTY,
+        { fontSize: "54px" },
+      );
+      this.luckLabelText.setName("text-luck-label");
+      this.luckLabelText.setOrigin(1, 0.5);
+      this.luckLabelText.setVisible(false);
+      this.fieldUI.add(this.luckLabelText);
 
-    this.arenaFlyout = new ArenaFlyout();
-    this.fieldUI.add(this.arenaFlyout);
-    this.fieldUI.moveBelow<Phaser.GameObjects.GameObject>(this.arenaFlyout, this.fieldOverlay);
+      this.arenaFlyout = new ArenaFlyout();
+      this.fieldUI.add(this.arenaFlyout);
+      this.fieldUI.moveBelow<Phaser.GameObjects.GameObject>(this.arenaFlyout, this.fieldOverlay);
 
-    this.updateUIPositions();
+      this.updateUIPositions();
 
-    this.damageNumberHandler = new DamageNumberHandler();
+      this.damageNumberHandler = new DamageNumberHandler();
 
-    this.spriteSparkleHandler = new PokemonSpriteSparkleHandler();
-    this.spriteSparkleHandler.setup();
+      this.spriteSparkleHandler = new PokemonSpriteSparkleHandler();
+      this.spriteSparkleHandler.setup();
 
-    this.pokemonInfoContainer = new PokemonInfoContainer(
-      this.game.canvas.width / 6 + 52,
-      -(this.game.canvas.height / 6) + 66,
-    );
-    this.pokemonInfoContainer.setup();
+      this.pokemonInfoContainer = new PokemonInfoContainer(
+        this.game.canvas.width / 6 + 52,
+        -(this.game.canvas.height / 6) + 66,
+      );
+      this.pokemonInfoContainer.setup();
 
-    this.fieldUI.add(this.pokemonInfoContainer);
+      this.fieldUI.add(this.pokemonInfoContainer);
+    }
 
     this.party = [];
 
@@ -1523,6 +1525,9 @@ export default class BattleScene extends SceneBase {
   }
 
   updateFieldScale(): Promise<void> {
+    if (headless) {
+      return Promise.resolve();
+    }
     return new Promise(resolve => {
       const fieldScale =
         Math.floor(
@@ -1539,6 +1544,10 @@ export default class BattleScene extends SceneBase {
   }
 
   setFieldScale(scale: number, instant = false): Promise<void> {
+    if (headless) {
+      this.field.scale = scale * 6;
+      return Promise.resolve();
+    }
     return new Promise(resolve => {
       scale *= 6;
       if (this.field.scale === scale) {
@@ -2067,6 +2076,9 @@ export default class BattleScene extends SceneBase {
   }
 
   updateUIPositions(): void {
+    if (headless) {
+      return;
+    }
     const enemyModifierCount = this.enemyModifiers.filter(m => m.isIconVisible()).length;
     const biomeWaveTextHeight = this.biomeWaveText.getBottomLeft().y - this.biomeWaveText.getTopLeft().y;
     this.biomeWaveText.setY(
@@ -2089,6 +2101,9 @@ export default class BattleScene extends SceneBase {
    * Pushes all {@linkcode Phaser.GameObjects.Text} objects in the top right to the bottom of the canvas
    */
   sendTextToBack(): void {
+    if (headless) {
+      return;
+    }
     this.fieldUI.sendToBack(this.biomeWaveText);
     this.fieldUI.sendToBack(this.moneyText);
     this.fieldUI.sendToBack(this.scoreText);
@@ -2964,7 +2979,9 @@ export default class BattleScene extends SceneBase {
   }
 
   setModifiersVisible(visible: boolean) {
-    [this.modifierBar, this.enemyModifierBar].map(m => m.setVisible(visible));
+    if (!headless) {
+      [this.modifierBar, this.enemyModifierBar].map(m => m.setVisible(visible));
+    }
   }
 
   // TODO: Document this
@@ -2993,9 +3010,11 @@ export default class BattleScene extends SceneBase {
     }
 
     this.updatePartyForModifiers(player ? this.getPlayerParty() : this.getEnemyParty(), instant);
-    (player ? this.modifierBar : this.enemyModifierBar).updateModifiers(modifiers);
-    if (!player) {
-      this.updateUIPositions();
+    if (!headless) {
+      (player ? this.modifierBar : this.enemyModifierBar).updateModifiers(modifiers);
+      if (!player) {
+        this.updateUIPositions();
+      }
     }
   }
 
@@ -3004,7 +3023,7 @@ export default class BattleScene extends SceneBase {
       Promise.allSettled(
         party.map(p => {
           p.calculateStats();
-          return p.updateInfo(instant);
+          return headless ? Promise.resolve() : p.updateInfo(instant);
         }),
       ).then(() => resolve());
     });

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -7,6 +7,7 @@ import {
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
@@ -191,7 +192,9 @@ async function summonPlayerPokemon() {
         pokemonName: getPokemonNameWithAffix(playerPokemon),
       }),
     );
-    globalScene.pbTray.hide();
+    if (!headless) {
+      globalScene.pbTray.hide();
+    }
     globalScene.trainer.setTexture(
       `trainer_${globalScene.gameData.gender === PlayerGender.FEMALE ? "f" : "m"}_back_pb`,
     );

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -1,6 +1,7 @@
 import { BattlerIndex } from "#enums/battler-index";
 import { BattleType } from "#enums/battle-type";
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import {
   applyAbAttrs,
@@ -424,8 +425,10 @@ export class EncounterPhase extends BattlePhase {
       const doSummon = () => {
         globalScene.currentBattle.started = true;
         globalScene.playBgm(undefined);
-        globalScene.pbTray.showPbTray(globalScene.getPlayerParty());
-        globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        if (!headless) {
+          globalScene.pbTray.showPbTray(globalScene.getPlayerParty());
+          globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        }
         const doTrainerSummon = () => {
           this.hideEnemyTrainer();
           const availablePartyMembers = globalScene.getEnemyParty().filter(p => !p.isFainted()).length;

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -9,6 +9,7 @@ import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { SwitchType } from "#enums/switch-type";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import { getCharVariantFromDialogue } from "../data/dialogue";
 import type { OptionSelectSettings } from "../data/mystery-encounters/utils/encounter-phase-utils";
 import { transitionMysteryEncounterIntroVisuals } from "../data/mystery-encounters/utils/encounter-phase-utils";
@@ -353,8 +354,10 @@ export class MysteryEncounterBattlePhase extends Phase {
       const doSummon = () => {
         globalScene.currentBattle.started = true;
         globalScene.playBgm();
-        globalScene.pbTray.showPbTray(globalScene.getPlayerParty());
-        globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        if (!headless) {
+          globalScene.pbTray.showPbTray(globalScene.getPlayerParty());
+          globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        }
         const doTrainerSummon = () => {
           this.hideEnemyTrainer();
           const availablePartyMembers = globalScene.getEnemyParty().filter(p => !p.isFainted()).length;

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -12,6 +12,7 @@ import { PartyMemberPokemonPhase } from "./party-member-pokemon-phase";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { applyPreSummonAbAttrs, PreSummonAbAttr } from "#app/data/abilities/ability";
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 
 export class SummonPhase extends PartyMemberPokemonPhase {
   // The union type is needed to keep typescript happy as these phases extend from SummonPhase
@@ -77,7 +78,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
           pokemonName: getPokemonNameWithAffix(this.getPokemon()),
         }),
       );
-      if (this.player) {
+      if (!headless && this.player) {
         globalScene.pbTray.hide();
       }
       globalScene.trainer.setTexture(
@@ -109,10 +110,14 @@ export class SummonPhase extends PartyMemberPokemonPhase {
         pokemonName,
       });
 
-      globalScene.pbTrayEnemy.hide();
+      if (!headless) {
+        globalScene.pbTrayEnemy.hide();
+      }
       globalScene.ui.showText(message, null, () => this.summon());
     } else if (globalScene.currentBattle.isBattleMysteryEncounter()) {
-      globalScene.pbTrayEnemy.hide();
+      if (!headless) {
+        globalScene.pbTrayEnemy.hide();
+      }
       this.summonWild();
     }
   }

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import {
   applyPreSummonAbAttrs,
   applyPreSwitchOutAbAttrs,
@@ -57,7 +58,9 @@ export class SwitchSummonPhase extends SummonPhase {
       }
       if (this.slotIndex > -1) {
         this.showEnemyTrainer(!(this.fieldIndex % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER);
-        globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        if (!headless) {
+          globalScene.pbTrayEnemy.showPbTray(globalScene.getEnemyParty());
+        }
       }
     }
 
@@ -209,7 +212,9 @@ export class SwitchSummonPhase extends SummonPhase {
     } else {
       globalScene.time.delayedCall(1500, () => {
         this.hideEnemyTrainer();
-        globalScene.pbTrayEnemy.hide();
+        if (!headless) {
+          globalScene.pbTrayEnemy.hide();
+        }
         showTextAndSummon();
       });
     }


### PR DESCRIPTION
## Summary
- avoid heavy UI initialization when running with `VITE_HEADLESS=1`
- guard modifier updates and field scaling when headless
- skip Pokéball tray actions in headless phases
- update test suite to pass

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6848bacdaddc8324992f70c1ad3ee37d