### PR TITLE
Implement fixed starter reset

### DIFF
--- a/src/rogue-env.ts
+++ b/src/rogue-env.ts
@@ -8,6 +8,7 @@ import type TransitionLogger from "#app/transition-logger";
 import type { TransitionRecord } from "#app/transition-logger";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
+import { SpeciesId } from "#enums/species-id";
 
 export enum RogueAction {
   /** Use the first move in the active Pokémon's moveset. */
@@ -78,7 +79,11 @@ export default class RogueEnv {
     this.scene.setSeed(this.seed);
     this.scene.resetSeed();
     this.scene.enableTutorials = false;
-    initSceneWithoutEncounterPhase(this.scene);
+    initSceneWithoutEncounterPhase(this.scene, [
+      SpeciesId.SQUIRTLE,
+      SpeciesId.BULBASAUR,
+      SpeciesId.CHARMANDER,
+    ]);
     this.scene.currentBattle.incrementTurn();
     this.scene.phaseManager.clearAllPhases();
     this.scene.phaseManager.pushNew("TurnInitPhase");

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -8,6 +8,7 @@ import Phaser from "phaser";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import BattleScene from "#app/battle-scene";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
+import { SpeciesId } from "#enums/species-id";
 import serializeState from "#app/utils/serialize";
 import { Command } from "#enums/command";
 import { CommandPhase } from "#app/phases/command-phase";
@@ -51,6 +52,17 @@ describe("rogue-env serialization", () => {
     env.step(RogueAction.FIGHT_1);
     const nextState = env.getState();
     expect(nextState.turn).toBeGreaterThanOrEqual(state.turn);
+  });
+
+  it("should initialize with standard starters", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const party = env.getState().playerParty.map(p => p.species);
+    expect(party).toEqual([
+      SpeciesId.SQUIRTLE,
+      SpeciesId.BULBASAUR,
+      SpeciesId.CHARMANDER,
+    ]);
   });
 });
 
@@ -218,7 +230,11 @@ describe("rogue-env parity", () => {
     scene.setSeed(seed);
     scene.resetSeed();
     scene.enableTutorials = false;
-    initSceneWithoutEncounterPhase(scene);
+    initSceneWithoutEncounterPhase(scene, [
+      SpeciesId.SQUIRTLE,
+      SpeciesId.BULBASAUR,
+      SpeciesId.CHARMANDER,
+    ]);
     scene.currentBattle.incrementTurn();
     scene.phaseManager.clearAllPhases();
     scene.phaseManager.pushNew("TurnInitPhase");


### PR DESCRIPTION
## Summary
- inject SpeciesId enum into rogue-env
- start RogueEnv with Squirtle, Bulbasaur and Charmander
- document starter lineup in tests
- update parity test to use fixed starters

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6848c2ce4e008324a85a2da872322abe