### PR TITLE
Implement bag action in env

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,8 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 ## 2. Expand the action space
 - [x] Add support for item usage, terastallization, capturing and other command types.
 - [x] Allow selecting a target when a move or switch requires it and handling of multi-turn moves.
-- Expose high level commands such as `Bag` and `Run` as discrete actions.
-- Update tests to cover the new actions and ensure backward compatibility.
+- [x] Expose high level commands such as `Bag` and `Run` as discrete actions.
+- [x] Update tests to cover the new actions and ensure backward compatibility.
 
 ## 3. Enrich state serialization
 - Include detailed move information (power, type, remaining PP) in `SerializedState`.

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -66,6 +66,8 @@ export enum RogueAction {
   SLOT_5 = 25,
   /** Choose the sixth party slot when switching. */
   SLOT_6 = 26,
+  /** Open the bag to use a Poké Ball. */
+  BAG = 27,
 }
 
 /**
@@ -145,6 +147,8 @@ export default class RogueEnv {
           phase.handleCommand(Command.BALL, action - RogueAction.BALL_1);
         } else if (action === RogueAction.RUN) {
           phase.handleCommand(Command.RUN, 0);
+        } else if (action === RogueAction.BAG) {
+          phase.handleCommand(Command.BALL, 0);
         } else if (action >= RogueAction.SWITCH_1 && action <= RogueAction.SWITCH_3) {
           phase.handleCommand(Command.POKEMON, action - RogueAction.SWITCH_1);
         }
@@ -200,6 +204,9 @@ export default class RogueEnv {
         }
       }
       const pokeballs = Object.values(this.scene.pokeballCounts ?? {});
+      if (pokeballs.some(c => c > 0)) {
+        actions.push(RogueAction.BAG);
+      }
       for (let i = 0; i < Math.min(5, pokeballs.length); i++) {
         if (pokeballs[i] > 0) {
           actions.push((RogueAction.BALL_1 + i) as RogueAction);

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -54,6 +54,30 @@ describe("rogue-env serialization", () => {
     expect(nextState.turn).toBeGreaterThanOrEqual(state.turn);
   });
 
+  it("should include bag action when balls are available", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const actions = env.getAvailableActions();
+    if (actions.includes(RogueAction.BALL_1)) {
+      expect(actions).toContain(RogueAction.BAG);
+    }
+  });
+
+  it("bag action should act like using the first ball", () => {
+    const seed = "bag-seed";
+    const env1 = new RogueEnv(seed);
+    env1.reset();
+    env1.step(RogueAction.BAG);
+    const bagState = env1.getState();
+
+    const env2 = new RogueEnv(seed);
+    env2.reset();
+    env2.step(RogueAction.BALL_1);
+    const ballState = env2.getState();
+
+    expect(bagState).toEqual(ballState);
+  });
+
   it("should initialize with standard starters", () => {
     const env = new RogueEnv();
     env.reset();
@@ -156,6 +180,8 @@ describe("rogue-env parity", () => {
         phase.handleCommand(Command.TERA, action - RogueAction.TERA_1);
       } else if (action >= RogueAction.BALL_1 && action <= RogueAction.BALL_5) {
         phase.handleCommand(Command.BALL, action - RogueAction.BALL_1);
+      } else if (action === RogueAction.BAG) {
+        phase.handleCommand(Command.BALL, 0);
       } else if (action === RogueAction.RUN) {
         phase.handleCommand(Command.RUN, 0);
       } else if (action >= RogueAction.SWITCH_1 && action <= RogueAction.SWITCH_3) {
@@ -184,6 +210,9 @@ describe("rogue-env parity", () => {
         }
       }
       const pokeballs = Object.values(scene.pokeballCounts ?? {});
+      if (pokeballs.some(c => c > 0)) {
+        actions.push(RogueAction.BAG);
+      }
       for (let i = 0; i < Math.min(5, pokeballs.length); i++) {
         if (pokeballs[i] > 0) {
           actions.push((RogueAction.BALL_1 + i) as RogueAction);


### PR DESCRIPTION
## Summary
- add `BAG` to `RogueAction`
- allow bag actions in `step` and available action calculations
- extend tests for bag functionality
- mark TODO task as complete

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_684935070de08324b2fa9ae7f389f211