### PR TITLE
Add move details to serialized state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 - [x] Update tests to cover the new actions and ensure backward compatibility.
 
 ## 3. Enrich state serialization
-- Include detailed move information (power, type, remaining PP) in `SerializedState`.
+- [x] Include detailed move information (power, type, remaining PP) in `SerializedState`.
 - Capture held items, stat boosts and volatile statuses for both player and enemy.
 - Expose arena features like hazards, terrain turns and wave index in a stable format.
 - Version the JSON schema so training data remains usable as the format evolves.

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -22,7 +22,7 @@ export interface SerializedPokemon {
   statStages: number[];
   /** Whether this Pokémon is currently active on the field. */
   active: boolean;
-  moves: { id: number; pp: number; maxPp: number }[];
+  moves: { id: number; type: number; power: number; pp: number; maxPp: number }[];
 }
 
 export interface SerializedState {
@@ -71,8 +71,14 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
     status: p.status?.effect ?? StatusEffect.NONE,
     items: p.getHeldItems().map(i => i.type.id),
     statStages: p.getStatStages(),
-    active: p.isActive(true),
-    moves: p.getMoveset().map(m => ({ id: m.moveId, pp: m.getMovePp() - m.ppUsed, maxPp: m.getMovePp() })),
+  active: p.isActive(true),
+    moves: p.getMoveset().map(m => ({
+      id: m.moveId,
+      type: m.getMove().type,
+      power: m.getMove().power,
+      pp: m.getMovePp() - m.ppUsed,
+      maxPp: m.getMovePp(),
+    })),
   };
 }
 

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -24,6 +24,10 @@ describe("rogue-env serialization", () => {
     expect(Array.isArray(state.enemyParty)).toBe(true);
     expect(state.playerParty[0]).toHaveProperty("species");
     expect(state.playerParty[0]).toHaveProperty("moves");
+    if (state.playerParty[0].moves.length > 0) {
+      expect(state.playerParty[0].moves[0]).toHaveProperty("type");
+      expect(state.playerParty[0].moves[0]).toHaveProperty("power");
+    }
     expect(state.playerParty[0]).toHaveProperty("status");
     expect(state.playerParty[0]).toHaveProperty("items");
     expect(Array.isArray(state.playerParty[0].items)).toBe(true);


### PR DESCRIPTION
## Summary
- enrich `SerializedState` with move type and power
- adjust tests for new serialization fields
- mark TODO item done for move details

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684937f04e70832481b7a4a6e985c999