### PR TITLE
Add battler tag serialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 
 ## 3. Enrich state serialization
 - [x] Include detailed move information (power, type, remaining PP) in `SerializedState`.
-- Capture held items, stat boosts and volatile statuses for both player and enemy.
+- [x] Capture held items, stat boosts and volatile statuses for both player and enemy.
 - Expose arena features like hazards, terrain turns and wave index in a stable format.
 - Version the JSON schema so training data remains usable as the format evolves.
 

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -5,6 +5,7 @@ import { BattleType } from "#enums/battle-type";
 import { BiomeId } from "#enums/biome-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { getPlayerShopModifierTypeOptionsForWave } from "#app/modifier/modifier-type";
 import { HealShopCostModifier } from "#app/modifier/modifier";
 import { NumberHolder } from "#app/utils/common";
@@ -20,6 +21,8 @@ export interface SerializedPokemon {
   items: string[];
   /** Array of seven in-battle stat stage values. */
   statStages: number[];
+  /** Active volatile battler tags with remaining turns. */
+  battlerTags: { type: BattlerTagType; turns: number }[];
   /** Whether this Pokémon is currently active on the field. */
   active: boolean;
   moves: { id: number; type: number; power: number; pp: number; maxPp: number }[];
@@ -71,7 +74,8 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
     status: p.status?.effect ?? StatusEffect.NONE,
     items: p.getHeldItems().map(i => i.type.id),
     statStages: p.getStatStages(),
-  active: p.isActive(true),
+    battlerTags: p.summonData.tags.map(t => ({ type: t.tagType, turns: t.turnCount })),
+    active: p.isActive(true),
     moves: p.getMoveset().map(m => ({
       id: m.moveId,
       type: m.getMove().type,

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -31,6 +31,10 @@ describe("rogue-env serialization", () => {
     expect(state.playerParty[0]).toHaveProperty("status");
     expect(state.playerParty[0]).toHaveProperty("items");
     expect(Array.isArray(state.playerParty[0].items)).toBe(true);
+    expect(state.playerParty[0]).toHaveProperty("statStages");
+    expect(Array.isArray(state.playerParty[0].statStages)).toBe(true);
+    expect(state.playerParty[0]).toHaveProperty("battlerTags");
+    expect(Array.isArray(state.playerParty[0].battlerTags)).toBe(true);
     expect(state).toHaveProperty("weather");
     expect(state).toHaveProperty("terrain");
     expect(state).toHaveProperty("playerActive");


### PR DESCRIPTION
## Summary
- track battler tags in serialized Pokémon data
- assert battler tags & stat boosts in tests
- mark TODO item for capturing items, boosts, and volatile statuses

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68493cf3310483249bd1a857b3882633