### PR TITLE
Implement hazard and terrain serialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 ## 3. Enrich state serialization
 - [x] Include detailed move information (power, type, remaining PP) in `SerializedState`.
 - [x] Capture held items, stat boosts and volatile statuses for both player and enemy.
-- Expose arena features like hazards, terrain turns and wave index in a stable format.
+- [x] Expose arena features like hazards, terrain turns and wave index in a stable format.
 - Version the JSON schema so training data remains usable as the format evolves.
 
 ## 4. Reward calculation and logging

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -41,6 +41,8 @@ export interface SerializedState {
   weather: number;
   /** Current terrain effect in the arena. */
   terrain: number;
+  /** Remaining turns on the active terrain effect. */
+  terrainTurns: number;
   /** Current wave number. */
   wave: number;
   /** Player's available money. */
@@ -54,7 +56,12 @@ export interface SerializedState {
   /** Number of terastallizations used by the player this arena. */
   playerTerasUsed: number;
   /** Active arena tags influencing the field. */
-  arenaTags: { type: ArenaTagType; side: ArenaTagSide; turns: number }[];
+  arenaTags: {
+    type: ArenaTagType;
+    side: ArenaTagSide;
+    turns: number;
+    layers?: number;
+  }[];
   /** Remaining Poké Ball counts by type. */
   pokeballCounts: { [type: number]: number };
   /** Active player modifiers with stack counts. */
@@ -104,6 +111,7 @@ export default function serializeState(scene: BattleScene): SerializedState {
     enemyActive: scene.getEnemyField().map(p => scene.getEnemyParty().indexOf(p)),
     weather: scene.arena.weather?.weatherType ?? 0,
     terrain: scene.arena.terrain?.terrainType ?? 0,
+    terrainTurns: scene.arena.terrain?.turnsLeft ?? 0,
     wave: scene.currentBattle?.waveIndex ?? 0,
     money: scene.money ?? 0,
     biome: scene.arena.biomeType as BiomeId,
@@ -113,7 +121,8 @@ export default function serializeState(scene: BattleScene): SerializedState {
     arenaTags: scene.arena.tags.map(t => ({
       type: t.tagType,
       side: t.side,
-      turns: t.turnCount,
+      turns: (t as any).turnCount ?? 0,
+      layers: (t as any).layers,
     })),
     pokeballCounts: { ...scene.pokeballCounts },
     playerModifiers: scene.modifiers.map(m => ({ id: m.type.id, stack: m.stackCount })),

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -37,6 +37,10 @@ describe("rogue-env serialization", () => {
     expect(Array.isArray(state.playerParty[0].battlerTags)).toBe(true);
     expect(state).toHaveProperty("weather");
     expect(state).toHaveProperty("terrain");
+    expect(state).toHaveProperty("terrainTurns");
+    expect(typeof state.terrainTurns).toBe("number");
+    expect(state).toHaveProperty("wave");
+    expect(typeof state.wave).toBe("number");
     expect(state).toHaveProperty("playerActive");
     expect(state).toHaveProperty("enemyActive");
     expect(Array.isArray(state.playerActive)).toBe(true);
@@ -53,6 +57,9 @@ describe("rogue-env serialization", () => {
     expect(state).toHaveProperty("playerTerasUsed");
     expect(state).toHaveProperty("arenaTags");
     expect(Array.isArray(state.arenaTags)).toBe(true);
+    if (state.arenaTags.length > 0) {
+      expect(state.arenaTags[0]).toHaveProperty("layers");
+    }
     expect(state.shopOptions).toBeUndefined();
     expect(Array.isArray(state.availableActions)).toBe(true);
     expect(state.availableActions).toEqual(env.getAvailableActions());


### PR DESCRIPTION
## Summary
- add terrain turn tracking and hazard layer details to serialized state
- update rogue-env tests for new fields
- mark TODO item about arena features complete

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6849a0e0a0888324b923585b7731ccc8