### PR TITLE
Add reward helpers and compressed logging

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,9 +19,8 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 - [x] Expose arena features like hazards, terrain turns and wave index in a stable format.
 - Version the JSON schema so training data remains usable as the format evolves.
 
-## 4. Reward calculation and logging
-- Provide helper functions to compute rewards after each step (e.g. damage dealt, fainted Pokémon, wave cleared).
-- Store `(state, action, reward, next_state, done)` tuples using `TransitionLogger` with optional compression or rotation.
+- [x] Provide helper functions to compute rewards after each step (e.g. damage dealt, fainted Pokémon, wave cleared).
+- [x] Store `(state, action, reward, next_state, done)` tuples using `TransitionLogger` with optional compression or rotation.
 - Add utilities to replay logged transitions to verify determinism.
 
 ## 5. Performance improvements

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,3 +1,4 @@
 export { default as RogueEnv, RogueAction } from "./rogue-env";
 export { default as TransitionLogger } from "./transition-logger";
 export type { TransitionRecord } from "./transition-logger";
+export { computeStepReward, getRewardComponents, DEFAULT_WEIGHTS } from "./reward";

--- a/src/env/reward.ts
+++ b/src/env/reward.ts
@@ -1,0 +1,53 @@
+export interface RewardWeights {
+  damageDealt: number;
+  damageTaken: number;
+  enemyFainted: number;
+  playerFainted: number;
+  waveCleared: number;
+}
+
+export const DEFAULT_WEIGHTS: RewardWeights = {
+  damageDealt: 1,
+  damageTaken: -1,
+  enemyFainted: 50,
+  playerFainted: -50,
+  waveCleared: 200,
+};
+
+import type { SerializedState } from "#app/utils/serialize";
+
+export function getRewardComponents(
+  prev: SerializedState,
+  next: SerializedState,
+) {
+  const prevEnemyHp = prev.enemyParty.reduce((s, p) => s + p.hp, 0);
+  const nextEnemyHp = next.enemyParty.reduce((s, p) => s + p.hp, 0);
+  const prevPlayerHp = prev.playerParty.reduce((s, p) => s + p.hp, 0);
+  const nextPlayerHp = next.playerParty.reduce((s, p) => s + p.hp, 0);
+
+  const enemyFainted = next.enemyParty.filter((p, i) => p.hp <= 0 && prev.enemyParty[i].hp > 0).length;
+  const playerFainted = next.playerParty.filter((p, i) => p.hp <= 0 && prev.playerParty[i].hp > 0).length;
+
+  return {
+    damageDealt: prevEnemyHp - nextEnemyHp,
+    damageTaken: prevPlayerHp - nextPlayerHp,
+    enemyFainted,
+    playerFainted,
+    waveCleared: next.wave > prev.wave ? 1 : 0,
+  };
+}
+
+export function computeStepReward(
+  prev: SerializedState,
+  next: SerializedState,
+  weights: RewardWeights = DEFAULT_WEIGHTS,
+): number {
+  const comps = getRewardComponents(prev, next);
+  return (
+    comps.damageDealt * weights.damageDealt +
+    comps.damageTaken * weights.damageTaken +
+    comps.enemyFainted * weights.enemyFainted +
+    comps.playerFainted * weights.playerFainted +
+    comps.waveCleared * weights.waveCleared
+  );
+}

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -6,6 +6,7 @@ import { randomString } from "#app/utils/common";
 import serializeState, { type SerializedState } from "#app/utils/serialize";
 import type TransitionLogger from "#env/transition-logger";
 import type { TransitionRecord } from "#env/transition-logger";
+import { computeStepReward } from "#env/reward";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
 import { SpeciesId } from "#enums/species-id";
@@ -134,7 +135,11 @@ export default class RogueEnv {
    * appropriate in‑game command. A custom function may also be passed to
    * manipulate the underlying {@link BattleScene} directly.
    */
-  step(action?: RogueAction | ((scene: BattleScene) => void), reward = 0, done = false): void {
+  step(
+    action?: RogueAction | ((scene: BattleScene) => void),
+    reward?: number,
+    done = false,
+  ): number {
     const prevState = this.getState();
     if (typeof action === "number") {
       const phase: any = this.scene.phaseManager.getCurrentPhase();
@@ -177,6 +182,10 @@ export default class RogueEnv {
       safety++;
     }
     const nextState = this.getState();
+    const computed = computeStepReward(prevState, nextState);
+    if (reward === undefined) {
+      reward = computed;
+    }
     if (this.logger) {
       const record: TransitionRecord = {
         state: prevState,
@@ -187,6 +196,7 @@ export default class RogueEnv {
       };
       this.logger.log(record);
     }
+    return reward;
   }
 
   /**

--- a/src/env/transition-logger.ts
+++ b/src/env/transition-logger.ts
@@ -1,6 +1,7 @@
 import type { SerializedState } from "#app/utils/serialize";
 import { promises as fs } from "node:fs";
 import { resolve } from "node:path";
+import { gzipSync, gunzipSync } from "node:zlib";
 
 export interface TransitionRecord {
   state: SerializedState;
@@ -32,9 +33,15 @@ export default class TransitionLogger {
   /**
    * Write the current log to a file in JSON format.
    */
-  async saveToFile(path: string): Promise<void> {
+  async saveToFile(path: string, compress = false): Promise<void> {
     const file = resolve(path);
-    await fs.writeFile(file, this.toJSON(), "utf8");
+    const data = this.toJSON();
+    if (compress) {
+      const buf = gzipSync(data);
+      await fs.writeFile(file, buf);
+    } else {
+      await fs.writeFile(file, data, "utf8");
+    }
   }
 
   /**
@@ -42,7 +49,13 @@ export default class TransitionLogger {
    */
   async loadFromFile(path: string): Promise<void> {
     const file = resolve(path);
-    const text = await fs.readFile(file, "utf8");
+    const buf = await fs.readFile(file);
+    let text: string;
+    try {
+      text = gunzipSync(buf).toString("utf8");
+    } catch {
+      text = buf.toString("utf8");
+    }
     this.records = JSON.parse(text) as TransitionRecord[];
   }
 }

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { RogueEnv, RogueAction, TransitionLogger } from "#env";
+import { RogueEnv, RogueAction, TransitionLogger, computeStepReward } from "#env";
 import Phaser from "phaser";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import BattleScene from "#app/battle-scene";
@@ -107,7 +107,9 @@ describe("rogue-env logging", () => {
     env.logger = new TransitionLogger();
     env.reset();
     const start = env.getState();
-    env.step(RogueAction.FIGHT_1, 1, false);
+    const r = env.step(RogueAction.FIGHT_1);
+    const expected = computeStepReward(start, env.getState());
+    expect(r).toBe(expected);
     const records = env.logger.getRecords();
     expect(records.length).toBe(1);
     expect(records[0].state).toEqual(start);
@@ -119,12 +121,12 @@ describe("rogue-env logging", () => {
     const env = new RogueEnv();
     env.logger = new TransitionLogger();
     env.reset();
-    env.step(RogueAction.FIGHT_1, 1, false);
+    env.step(RogueAction.FIGHT_1);
 
     const file = join(tmpdir(), `transitions-${Date.now()}.json`);
-    await env.logger!.saveToFile(file);
-    const contents = await fs.readFile(file, "utf8");
-    expect(contents).toBe(env.logger!.toJSON());
+    await env.logger!.saveToFile(file, true);
+    const contents = await fs.readFile(file);
+    expect(contents.length).toBeGreaterThan(0);
     await fs.unlink(file);
   });
 
@@ -132,10 +134,10 @@ describe("rogue-env logging", () => {
     const env = new RogueEnv();
     env.logger = new TransitionLogger();
     env.reset();
-    env.step(RogueAction.FIGHT_1, 1, false);
+    env.step(RogueAction.FIGHT_1);
 
     const file = join(tmpdir(), `transitions-${Date.now()}.json`);
-    await env.logger.saveToFile(file);
+    await env.logger.saveToFile(file, true);
 
     const logger2 = new TransitionLogger();
     await logger2.loadFromFile(file);


### PR DESCRIPTION
## Summary
- compute rewards between serialized states and expose helpers
- log automatic rewards from `RogueEnv.step`
- allow saving TransitionLogger output compressed
- test reward calculation and compressed logging
- check off related TODO items

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849a30cbc288324b87c17bc67150865