### PR TITLE
Add transition replay utility

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 
 - [x] Provide helper functions to compute rewards after each step (e.g. damage dealt, fainted Pokémon, wave cleared).
 - [x] Store `(state, action, reward, next_state, done)` tuples using `TransitionLogger` with optional compression or rotation.
-- Add utilities to replay logged transitions to verify determinism.
+- [x] Add utilities to replay logged transitions to verify determinism.
 
 ## 5. Performance improvements
 - Skip animations and audio entirely when `headless` to maximise simulation speed.

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -2,3 +2,4 @@ export { default as RogueEnv, RogueAction } from "./rogue-env";
 export { default as TransitionLogger } from "./transition-logger";
 export type { TransitionRecord } from "./transition-logger";
 export { computeStepReward, getRewardComponents, DEFAULT_WEIGHTS } from "./reward";
+export { replayTransitions, replayLogFile } from "./replay";

--- a/src/env/replay.ts
+++ b/src/env/replay.ts
@@ -1,0 +1,48 @@
+import RogueEnv from "./rogue-env";
+import TransitionLogger, { type TransitionRecord } from "./transition-logger";
+
+export interface ReplayResult {
+  /** Whether all states and rewards matched the original log. */
+  deterministic: boolean;
+  /** Records produced when replaying the log. */
+  records: TransitionRecord[];
+}
+
+/**
+ * Replay a sequence of transition records with a fresh environment.
+ *
+ * Returns the newly generated records and whether they match the originals.
+ */
+export function replayTransitions(records: TransitionRecord[], seed?: string): ReplayResult {
+  const env = new RogueEnv(seed);
+  env.reset(seed);
+  const out: TransitionRecord[] = [];
+  let deterministic = true;
+
+  for (const r of records) {
+    const before = env.getState();
+    if (JSON.stringify(before) !== JSON.stringify(r.state)) {
+      deterministic = false;
+    }
+    const reward = env.step(r.action, undefined, r.done);
+    const after = env.getState();
+    if (
+      JSON.stringify(after) !== JSON.stringify(r.nextState) ||
+      reward !== r.reward
+    ) {
+      deterministic = false;
+    }
+    out.push({ state: before, action: r.action, reward, nextState: after, done: r.done });
+  }
+
+  return { deterministic, records: out };
+}
+
+/**
+ * Convenience helper to load a log file and replay its transitions.
+ */
+export async function replayLogFile(path: string, seed?: string): Promise<ReplayResult> {
+  const logger = new TransitionLogger();
+  await logger.loadFromFile(path);
+  return replayTransitions(logger.getRecords(), seed);
+}

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { RogueEnv, RogueAction, TransitionLogger, computeStepReward } from "#env";
+import { RogueEnv, RogueAction, TransitionLogger, computeStepReward, replayTransitions } from "#env";
 import Phaser from "phaser";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import BattleScene from "#app/battle-scene";
@@ -144,6 +144,24 @@ describe("rogue-env logging", () => {
     expect(logger2.getRecords()).toEqual(env.logger.getRecords());
 
     await fs.unlink(file);
+  });
+});
+
+describe("transition replay", () => {
+  it("should reproduce recorded transitions", async () => {
+    const seed = "replay-seed";
+    const env = new RogueEnv(seed);
+    const logger = new TransitionLogger();
+    env.logger = logger;
+    env.reset();
+    env.step(RogueAction.FIGHT_1);
+    env.step(RogueAction.FIGHT_1);
+
+    const records = logger.getRecords();
+    const result = replayTransitions(records, seed);
+
+    expect(result.deterministic).toBe(true);
+    expect(result.records).toEqual(records);
   });
 });
 


### PR DESCRIPTION
## Summary
- implement `replayTransitions` helper and file loader
- export replay helpers from env module
- test replay functionality
- mark TODO item as completed

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849a7e8a45083248cc3fc4d15026760