### PR TITLE
Implement headless mode optimizations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 - [x] Store `(state, action, reward, next_state, done)` tuples using `TransitionLogger` with optional compression or rotation.
 - [x] Add utilities to replay logged transitions to verify determinism.
 
-## 5. Performance improvements
-- Skip animations and audio entirely when `headless` to maximise simulation speed.
+- [x] Skip animations and audio entirely when `headless` to maximise simulation speed.
 - Offer a "fast forward" option to progress multiple internal phases within a single call to `step()`.
 - Benchmark large batches of steps to identify remaining bottlenecks.
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -375,6 +375,14 @@ export default class BattleScene extends SceneBase {
     this.eventManager = new TimedEventManager();
     this.updateGameInfo();
     initGlobalScene(this);
+    if (headless) {
+      this.moveAnimations = false;
+      this.masterVolume = 0;
+      this.bgmVolume = 0;
+      this.fieldVolume = 0;
+      this.uiVolume = 0;
+      this.seVolume = 0;
+    }
   }
 
   loadPokemonAtlas(key: string, atlasPath: string, experimental?: boolean) {
@@ -687,14 +695,16 @@ export default class BattleScene extends SceneBase {
 
     const defaultMoves = [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE];
 
-    Promise.all([
-      Promise.all(loadPokemonAssets),
-      initCommonAnims().then(() => loadCommonAnimAssets(true)),
-      Promise.all(
-        [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE].map(m => initMoveAnim(m)),
-      ).then(() => loadMoveAnimAssets(defaultMoves, true)),
-      this.initStarterColors(),
-    ]).then(() => {
+    const tasks = [Promise.all(loadPokemonAssets), this.initStarterColors()];
+    if (!headless) {
+      tasks.push(
+        initCommonAnims().then(() => loadCommonAnimAssets(true)),
+        Promise.all(
+          [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE].map(m => initMoveAnim(m)),
+        ).then(() => loadMoveAnimAssets(defaultMoves, true)),
+      );
+    }
+    Promise.all(tasks).then(() => {
       if (!headless) {
         this.phaseManager.pushNew("LoginPhase");
         this.phaseManager.pushNew("TitlePhase");
@@ -2196,6 +2206,9 @@ export default class BattleScene extends SceneBase {
   }
 
   playBgm(bgmName?: string, fadeOut?: boolean): void {
+    if (headless) {
+      return;
+    }
     if (bgmName === undefined) {
       bgmName = this.currentBattle?.getBgmOverride() || this.arena?.bgm;
     }
@@ -2257,6 +2270,9 @@ export default class BattleScene extends SceneBase {
   }
 
   pauseBgm(): boolean {
+    if (headless) {
+      return false;
+    }
     if (this.bgm && !this.bgm.pendingRemove && this.bgm.isPlaying) {
       this.bgm.pause();
       return true;
@@ -2265,6 +2281,9 @@ export default class BattleScene extends SceneBase {
   }
 
   resumeBgm(): boolean {
+    if (headless) {
+      return false;
+    }
     if (this.bgm && !this.bgm.pendingRemove && this.bgm.isPaused) {
       this.bgm.resume();
       return true;
@@ -2273,6 +2292,9 @@ export default class BattleScene extends SceneBase {
   }
 
   updateSoundVolume(): void {
+    if (headless) {
+      return;
+    }
     if (this.sound) {
       for (const sound of this.sound.getAllPlaying() as AnySound[]) {
         if (this.bgmCache.has(sound.key)) {
@@ -2298,6 +2320,9 @@ export default class BattleScene extends SceneBase {
   }
 
   fadeOutBgm(duration = 500, destroy = true): boolean {
+    if (headless) {
+      return false;
+    }
     if (!this.bgm) {
       return false;
     }
@@ -2317,6 +2342,9 @@ export default class BattleScene extends SceneBase {
    * @param delay
    */
   fadeAndSwitchBgm(newBgmKey: string, destroy = false, delay = 2000) {
+    if (headless) {
+      return;
+    }
     this.fadeOutBgm(delay, destroy);
     this.time.delayedCall(delay, () => {
       this.playBgm(newBgmKey);
@@ -2324,6 +2352,9 @@ export default class BattleScene extends SceneBase {
   }
 
   playSound(sound: string | AnySound, config?: object): AnySound {
+    if (headless) {
+      return sound as AnySound;
+    }
     const key = typeof sound === "string" ? sound : sound.key;
     config = config ?? {};
     try {
@@ -2365,6 +2396,9 @@ export default class BattleScene extends SceneBase {
   }
 
   playSoundWithoutBgm(soundName: string, pauseDuration?: number): AnySound {
+    if (headless) {
+      return { key: soundName } as AnySound;
+    }
     this.bgmCache.add(soundName);
     const resumeBgm = this.pauseBgm();
     this.playSound(soundName);

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -203,6 +203,17 @@ describe("headless flag", () => {
     delete process.env.VITE_HEADLESS;
     vi.resetModules();
   });
+
+  it("should disable animations and audio", async () => {
+    process.env.VITE_HEADLESS = "1";
+    vi.resetModules();
+    const { default: BattleScene } = await import("#app/battle-scene");
+    const scene = new BattleScene();
+    expect(scene.moveAnimations).toBe(false);
+    expect(scene.masterVolume).toBe(0);
+    delete process.env.VITE_HEADLESS;
+    vi.resetModules();
+  });
 });
 
 describe("rogue-env parity", () => {


### PR DESCRIPTION
## Summary
- disable battle animations and audio when `VITE_HEADLESS` is set
- avoid loading animation assets in headless mode
- add tests for headless behaviour
- update TODO

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6849ad4e0f708324905164c6bbb9a2dc