### PR TITLE
Implement fast forward option in RogueEnv

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 
 ## 5. Performance Improvements
 - [x] Skip animations and audio entirely when `headless` to maximise simulation speed.
-- Offer a "fast forward" option to progress multiple internal phases within a single call to `step()`.
+- [x] Offer a "fast forward" option to progress multiple internal phases within a single call to `step()`.
 - Benchmark large batches of steps to identify remaining bottlenecks.
 
 ## 6. Integration and packaging

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -139,64 +139,73 @@ export default class RogueEnv {
     action?: RogueAction | ((scene: BattleScene) => void),
     reward?: number,
     done = false,
+    fastForward = 1,
   ): number {
-    const prevState = this.getState();
-    if (typeof action === "number") {
-      const phase: any = this.scene.phaseManager.getCurrentPhase();
-      if (phase?.handleCommand) {
-        if (action <= RogueAction.FIGHT_4) {
-          phase.handleCommand(Command.FIGHT, action);
-        } else if (action >= RogueAction.TERA_1 && action <= RogueAction.TERA_4) {
-          phase.handleCommand(Command.TERA, action - RogueAction.TERA_1);
-        } else if (action >= RogueAction.BALL_1 && action <= RogueAction.BALL_5) {
-          phase.handleCommand(Command.BALL, action - RogueAction.BALL_1);
-        } else if (action === RogueAction.RUN) {
-          phase.handleCommand(Command.RUN, 0);
-        } else if (action === RogueAction.BAG) {
-          phase.handleCommand(Command.BALL, 0);
-        } else if (action >= RogueAction.SWITCH_1 && action <= RogueAction.SWITCH_3) {
-          phase.handleCommand(Command.POKEMON, action - RogueAction.SWITCH_1);
+    let total = 0;
+    for (let i = 0; i < fastForward; i++) {
+      const prevState = this.getState();
+
+      if (typeof action === "number") {
+        const phase: any = this.scene.phaseManager.getCurrentPhase();
+        if (phase?.handleCommand) {
+          if (action <= RogueAction.FIGHT_4) {
+            phase.handleCommand(Command.FIGHT, action);
+          } else if (action >= RogueAction.TERA_1 && action <= RogueAction.TERA_4) {
+            phase.handleCommand(Command.TERA, action - RogueAction.TERA_1);
+          } else if (action >= RogueAction.BALL_1 && action <= RogueAction.BALL_5) {
+            phase.handleCommand(Command.BALL, action - RogueAction.BALL_1);
+          } else if (action === RogueAction.RUN) {
+            phase.handleCommand(Command.RUN, 0);
+          } else if (action === RogueAction.BAG) {
+            phase.handleCommand(Command.BALL, 0);
+          } else if (action >= RogueAction.SWITCH_1 && action <= RogueAction.SWITCH_3) {
+            phase.handleCommand(Command.POKEMON, action - RogueAction.SWITCH_1);
+          }
+        } else if (phase?.constructor.name === "SelectTargetPhase") {
+          const handler: any = this.scene.ui.getHandler();
+          const cb = handler?.targetSelectCallback as ((targets: number[]) => void) | undefined;
+          if (cb && action >= RogueAction.TARGET_1 && action <= RogueAction.TARGET_4) {
+            cb([action - RogueAction.TARGET_1]);
+          }
+        } else if (phase?.constructor.name === "SwitchPhase") {
+          const handler: any = this.scene.ui.getHandler();
+          const cb = handler?.selectCallback as ((slot: number, option: number) => void) | undefined;
+          if (cb && action >= RogueAction.SLOT_1 && action <= RogueAction.SLOT_6) {
+            cb(action - RogueAction.SLOT_1, 1);
+          }
         }
-      } else if (phase?.constructor.name === "SelectTargetPhase") {
-        const handler: any = this.scene.ui.getHandler();
-        const cb = handler?.targetSelectCallback as ((targets: number[]) => void) | undefined;
-        if (cb && action >= RogueAction.TARGET_1 && action <= RogueAction.TARGET_4) {
-          cb([action - RogueAction.TARGET_1]);
-        }
-      } else if (phase?.constructor.name === "SwitchPhase") {
-        const handler: any = this.scene.ui.getHandler();
-        const cb = handler?.selectCallback as ((slot: number, option: number) => void) | undefined;
-        if (cb && action >= RogueAction.SLOT_1 && action <= RogueAction.SLOT_6) {
-          cb(action - RogueAction.SLOT_1, 1);
-        }
+      } else if (typeof action === "function") {
+        action(this.scene);
       }
-    } else if (typeof action === "function") {
-      action(this.scene);
-    }
-    this.scene.phaseManager.shiftPhase();
-    let phase = this.scene.phaseManager.getCurrentPhase();
-    let safety = 0;
-    while (phase && !(phase instanceof CommandPhase) && safety < 100) {
+
       this.scene.phaseManager.shiftPhase();
-      phase = this.scene.phaseManager.getCurrentPhase();
-      safety++;
+      let phase = this.scene.phaseManager.getCurrentPhase();
+      let safety = 0;
+      while (phase && !(phase instanceof CommandPhase) && safety < 100) {
+        this.scene.phaseManager.shiftPhase();
+        phase = this.scene.phaseManager.getCurrentPhase();
+        safety++;
+      }
+
+      const nextState = this.getState();
+      const computed = computeStepReward(prevState, nextState);
+      const stepReward = reward === undefined ? computed : reward;
+
+      if (this.logger) {
+        const record: TransitionRecord = {
+          state: prevState,
+          action: typeof action === "number" ? action : -1,
+          reward: stepReward,
+          nextState,
+          done: done && i === fastForward - 1,
+        };
+        this.logger.log(record);
+      }
+
+      total += stepReward;
     }
-    const nextState = this.getState();
-    const computed = computeStepReward(prevState, nextState);
-    if (reward === undefined) {
-      reward = computed;
-    }
-    if (this.logger) {
-      const record: TransitionRecord = {
-        state: prevState,
-        action: typeof action === "number" ? action : -1,
-        reward,
-        nextState,
-        done,
-      };
-      this.logger.log(record);
-    }
-    return reward;
+
+    return total;
   }
 
   /**

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -192,6 +192,21 @@ describe("rogue-env progression", () => {
     expect(next.phase).toBe("CommandPhase");
     expect(next.turn).toBeGreaterThan(start.turn);
   });
+
+  it("should fast forward multiple steps with a single call", () => {
+    const env = new RogueEnv();
+    env.reset();
+
+    env.step(RogueAction.FIGHT_1, undefined, false, 2);
+    const ffState = env.getState();
+
+    env.reset();
+    env.step(RogueAction.FIGHT_1);
+    env.step(RogueAction.FIGHT_1);
+    const twoState = env.getState();
+
+    expect(ffState).toEqual(twoState);
+  });
 });
 
 describe("headless flag", () => {


### PR DESCRIPTION
## Summary
- add `fastForward` parameter to `RogueEnv.step()` to repeat actions in a single call
- test repeated steps via `fastForward`
- mark TODO for fast-forward option as complete

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849b1e701f88324bb78e1c18115ca1b