### PR TITLE
Add RogueEnv benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ You can also provide optional environment variables:
 
 The optional first argument specifies how many `step()` calls to run (defaults to the value of `ROGUE_STEPS` or 2). If a path is provided as the second argument, or via `ROGUE_LOG_PATH`, the transition log is written there; otherwise it prints to STDOUT.
 
+To benchmark environment performance, run:
+
+```bash
+npm run env:bench -- 1000
+```
+
+This executes a given number of steps and reports the steps per second. `ROGUE_BENCH_STEPS` and `ROGUE_SEED` can also be provided as environment variables.
+
 
 ## 🪧 To Do
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 ## 5. Performance Improvements
 - [x] Skip animations and audio entirely when `headless` to maximise simulation speed.
 - [x] Offer a "fast forward" option to progress multiple internal phases within a single call to `step()`.
-- Benchmark large batches of steps to identify remaining bottlenecks.
+- [x] Benchmark large batches of steps to identify remaining bottlenecks.
 
 ## 6. Integration and packaging
 - Provide an npm script or Dockerfile to run training sessions out of the box.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "update-version:patch": "npm version patch --force --no-git-tag-version",
     "update-version:minor": "npm version minor --force --no-git-tag-version",
     "update-locales:remote": "git submodule update --progress --init --recursive --force --remote",
-    "env:demo": "npx tsx scripts/rogue-env-demo.ts"
+    "env:demo": "npx tsx scripts/rogue-env-demo.ts",
+    "env:bench": "npx tsx scripts/rogue-env-benchmark.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/scripts/rogue-env-benchmark.ts
+++ b/scripts/rogue-env-benchmark.ts
@@ -1,0 +1,9 @@
+import { benchmark } from "#env";
+
+const steps = parseInt(process.argv[2] ?? process.env.ROGUE_BENCH_STEPS ?? "1000", 10);
+const seed = process.env.ROGUE_SEED;
+
+const result = await benchmark(steps, seed);
+const seconds = (result.ms / 1000).toFixed(2);
+const sps = result.sps.toFixed(2);
+console.log(`Executed ${result.steps} steps in ${seconds}s (${sps} steps/s)`);

--- a/src/env/benchmark.ts
+++ b/src/env/benchmark.ts
@@ -1,0 +1,22 @@
+import { RogueEnv, RogueAction } from "./index";
+
+export interface BenchmarkResult {
+  steps: number;
+  ms: number;
+  sps: number;
+}
+
+export async function benchmark(steps = 1000, seed?: string): Promise<BenchmarkResult> {
+  const env = new RogueEnv(seed);
+  env.reset();
+  const start = performance.now();
+  for (let i = 0; i < steps; i++) {
+    const actions = env.getAvailableActions();
+    const action = actions.includes(RogueAction.FIGHT_1) ? RogueAction.FIGHT_1 : actions[0];
+    env.step(action);
+  }
+  const ms = performance.now() - start;
+  return { steps, ms, sps: (steps / ms) * 1000 };
+}
+
+export default benchmark;

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -3,3 +3,4 @@ export { default as TransitionLogger } from "./transition-logger";
 export type { TransitionRecord } from "./transition-logger";
 export { computeStepReward, getRewardComponents, DEFAULT_WEIGHTS } from "./reward";
 export { replayTransitions, replayLogFile } from "./replay";
+export { benchmark } from "./benchmark";

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -356,3 +356,25 @@ describe("rogue-env parity", () => {
     expect(states).toEqual(envStates);
   });
 });
+
+describe("benchmark utility", () => {
+  it("should measure steps per second", async () => {
+    vi.doMock("#env/rogue-env", () => {
+      const mockStep = vi.fn();
+      return {
+        default: class {
+          constructor() {}
+          reset() {}
+          getAvailableActions() { return [0]; }
+          step() { mockStep(); }
+        },
+        RogueAction: { FIGHT_1: 0 },
+      };
+    });
+    const { benchmark } = await import("#env");
+    const result = await benchmark(3, "seed");
+    expect(result.steps).toBe(3);
+    expect(result.sps).toBeGreaterThan(0);
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary
- add benchmark helper and CLI
- document `env:bench` in README
- export benchmark from env module
- mark TODO item complete
- test benchmark utility with mocked env

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6849b44315c48324b745fd5974212cd1