### PR TITLE
Add challenge selection support

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -200,7 +200,11 @@ export default class RogueEnv {
           if (cb && action >= RogueAction.SLOT_1 && action <= RogueAction.SLOT_6) {
             cb(action - RogueAction.SLOT_1, 1);
           }
-        } else if (phase?.constructor.name === "SelectModifierPhase" || phase?.constructor.name === "SelectBiomePhase") {
+        } else if (
+          phase?.constructor.name === "SelectModifierPhase" ||
+          phase?.constructor.name === "SelectBiomePhase" ||
+          phase?.constructor.name === "SelectChallengePhase"
+        ) {
           const handler: any = this.scene.ui.getHandler();
           const buttonMap: Record<RogueAction, Button> = {
             [RogueAction.UI_ACTION]: Button.ACTION,
@@ -326,7 +330,10 @@ export default class RogueEnv {
           actions.push((RogueAction.SLOT_1 + i) as RogueAction);
         }
       }
-    } else if (phase?.constructor.name === "SelectModifierPhase") {
+    } else if (
+      phase?.constructor.name === "SelectModifierPhase" ||
+      phase?.constructor.name === "SelectChallengePhase"
+    ) {
       actions.push(
         RogueAction.UI_ACTION,
         RogueAction.UI_CANCEL,

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -227,6 +227,16 @@ describe("rogue-env progression", () => {
     env.step(RogueAction.UI_ACTION);
     expect(spy).toHaveBeenCalled();
   });
+
+  it("should expose ui actions during challenge selection", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const spy = vi.fn();
+    env.scene.phaseManager.currentPhase = { constructor: { name: "SelectChallengePhase" } } as any;
+    env.scene.ui.getHandler = vi.fn().mockReturnValue({ processInput: spy } as any);
+    env.step(RogueAction.UI_ACTION);
+    expect(spy).toHaveBeenCalled();
+  });
 });
 
 describe("rogue-env termination", () => {


### PR DESCRIPTION
## Summary
- handle `SelectChallengePhase` in `RogueEnv`
- expose UI actions during challenge selection
- test new phase handling

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849cd3460888324bf05626eb7be8705