### PR TITLE
Add learn move phase actions

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -88,6 +88,16 @@ export enum RogueAction {
   UI_LEFT = 35,
   /** Move the UI cursor right. */
   UI_RIGHT = 36,
+  /** Reject learning the offered move. */
+  LEARN_REJECT = 37,
+  /** Replace the first move when learning a new one. */
+  LEARN_REPLACE_1 = 38,
+  /** Replace the second move when learning a new one. */
+  LEARN_REPLACE_2 = 39,
+  /** Replace the third move when learning a new one. */
+  LEARN_REPLACE_3 = 40,
+  /** Replace the fourth move when learning a new one. */
+  LEARN_REPLACE_4 = 41,
 }
 
 /**
@@ -205,6 +215,19 @@ export default class RogueEnv {
           const cb = handler?.selectCallback as ((slot: number, option: number) => void) | undefined;
           if (cb && action >= RogueAction.SLOT_1 && action <= RogueAction.SLOT_6) {
             cb(action - RogueAction.SLOT_1, 1);
+          }
+        } else if (phase?.constructor.name === "LearnMovePhase") {
+          const pokemon = phase.getPokemon?.() as any;
+          if (action === RogueAction.LEARN_REJECT) {
+            /* no-op */
+          } else if (
+            action >= RogueAction.LEARN_REPLACE_1 &&
+            action <= RogueAction.LEARN_REPLACE_4 &&
+            pokemon
+          ) {
+            const idx = action - RogueAction.LEARN_REPLACE_1;
+            const moveId = (phase as any).moveId;
+            pokemon.setMove(idx, moveId);
           }
         } else if (
           phase?.constructor.name === "SelectModifierPhase" ||
@@ -335,6 +358,17 @@ export default class RogueEnv {
         if (p.hp > 0 && !p.isActive(true)) {
           actions.push((RogueAction.SLOT_1 + i) as RogueAction);
         }
+      }
+    } else if (phase?.constructor.name === "LearnMovePhase") {
+      const pokemon = phase.getPokemon?.() as any;
+      if (pokemon?.getMoveset().length >= 4) {
+        actions.push(
+          RogueAction.LEARN_REJECT,
+          RogueAction.LEARN_REPLACE_1,
+          RogueAction.LEARN_REPLACE_2,
+          RogueAction.LEARN_REPLACE_3,
+          RogueAction.LEARN_REPLACE_4,
+        );
       }
     } else if (
       phase?.constructor.name === "SelectModifierPhase" ||

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { RogueEnv, RogueAction, TransitionLogger, computeStepReward, replayTransitions } from "#env";
+import { MoveId } from "#enums/move-id";
 import Phaser from "phaser";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import BattleScene from "#app/battle-scene";
@@ -236,6 +237,43 @@ describe("rogue-env progression", () => {
     env.scene.ui.getHandler = vi.fn().mockReturnValue({ processInput: spy } as any);
     env.step(RogueAction.UI_ACTION);
     expect(spy).toHaveBeenCalled();
+  });
+
+  it("should handle learn move rejection", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const p = env.scene.getPlayerParty()[0];
+    for (let i = 0; i < 4; i++) {
+      p.setMove(i, MoveId.SPLASH);
+    }
+    env.scene.phaseManager.currentPhase = {
+      constructor: { name: "LearnMovePhase" },
+      getPokemon: () => p,
+      moveId: MoveId.TACKLE,
+    } as any;
+    env.step(RogueAction.LEARN_REJECT);
+    expect(p.getMoveset().map(m => m.moveId)).toEqual([
+      MoveId.SPLASH,
+      MoveId.SPLASH,
+      MoveId.SPLASH,
+      MoveId.SPLASH,
+    ]);
+  });
+
+  it("should replace selected move during learn move phase", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const p = env.scene.getPlayerParty()[0];
+    for (let i = 0; i < 4; i++) {
+      p.setMove(i, MoveId.SPLASH);
+    }
+    env.scene.phaseManager.currentPhase = {
+      constructor: { name: "LearnMovePhase" },
+      getPokemon: () => p,
+      moveId: MoveId.TACKLE,
+    } as any;
+    env.step(RogueAction.LEARN_REPLACE_2);
+    expect(p.getMoveset()[1].moveId).toBe(MoveId.TACKLE);
   });
 });
 


### PR DESCRIPTION
## Summary
- expand RogueAction enum for LearnMovePhase choices
- allow RogueEnv to handle LearnMovePhase
- expose available actions when learning moves
- test rejecting and replacing moves in headless env

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849deb4f14c83249fb8ad3125a79ef2