### PR TITLE
Automate evolution and egg phases

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -12,6 +12,8 @@ import GameWrapper from "#test/testUtils/gameWrapper";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
 import { SpeciesId } from "#enums/species-id";
 import { TerastallizeAccessModifier } from "#app/modifier/modifier";
+import { LearnMoveSituation } from "#enums/learn-move-situation";
+import { EVOLVE_MOVE } from "#app/data/balance/pokemon-level-moves";
 
 export enum RogueAction {
   /** Use the first move in the active Pokémon's moveset. */
@@ -154,6 +156,7 @@ export default class RogueEnv {
     this.scene.setSeed(this.seed);
     this.scene.resetSeed();
     this.scene.enableTutorials = false;
+    this.scene.eggSkipPreference = 2;
     initSceneWithoutEncounterPhase(this.scene, [SpeciesId.SQUIRTLE, SpeciesId.BULBASAUR, SpeciesId.CHARMANDER]);
     this.scene.currentBattle.incrementTurn();
     this.scene.phaseManager.clearAllPhases();
@@ -250,6 +253,39 @@ export default class RogueEnv {
         }
       } else if (typeof action === "function") {
         action(this.scene);
+      }
+
+      const autoPhase: any = this.scene.phaseManager.getCurrentPhase();
+      if (autoPhase?.constructor?.name === "EggHatchPhase" || autoPhase?.constructor?.name === "EggSummaryPhase") {
+        if (autoPhase.constructor.name === "EggHatchPhase") {
+          const lapse = autoPhase.eggLapsePhase;
+          lapse?.hatchEggSilently?.(autoPhase.egg);
+        }
+        autoPhase.end?.();
+      } else if (autoPhase?.constructor?.name === "EvolutionPhase" || autoPhase?.constructor?.name === "FormChangePhase") {
+        const pokemon = autoPhase.pokemon;
+        const evolution = autoPhase.evolution;
+        const lastLevel = autoPhase.lastLevel ?? 0;
+        if (pokemon && evolution) {
+          pokemon.evolve?.(evolution, pokemon.species);
+          const situation = autoPhase.fusionSpeciesEvolved
+            ? LearnMoveSituation.EVOLUTION_FUSED
+            : pokemon.fusionSpecies
+              ? LearnMoveSituation.EVOLUTION_FUSED_BASE
+              : LearnMoveSituation.EVOLUTION;
+          const levelMoves = pokemon
+            .getLevelMoves(lastLevel + 1, true, false, false, situation)
+            .filter((lm: any) => lm[0] === EVOLVE_MOVE);
+          for (const lm of levelMoves) {
+            this.scene.phaseManager.unshiftNew(
+              "LearnMovePhase",
+              this.scene.getPlayerParty().indexOf(pokemon),
+              lm[1],
+            );
+          }
+        }
+        this.scene.phaseManager.unshiftNew("EndEvolutionPhase");
+        autoPhase.end?.();
       }
 
       this.scene.phaseManager.shiftPhase();

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -275,6 +275,51 @@ describe("rogue-env progression", () => {
     env.step(RogueAction.LEARN_REPLACE_2);
     expect(p.getMoveset()[1].moveId).toBe(MoveId.TACKLE);
   });
+
+  it("should progress egg phases automatically", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const hatchSpy = vi.fn();
+    const endSpy = vi.fn();
+    env.scene.phaseManager.currentPhase = {
+      constructor: { name: "EggHatchPhase" },
+      eggLapsePhase: { hatchEggSilently: hatchSpy },
+      egg: {},
+      end: endSpy,
+    } as any;
+    env.step();
+    expect(hatchSpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalled();
+
+    env.scene.phaseManager.currentPhase = {
+      constructor: { name: "EggSummaryPhase" },
+      end: endSpy,
+    } as any;
+    env.step();
+    expect(endSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should complete evolution phases automatically", () => {
+    const env = new RogueEnv();
+    env.reset();
+    const pokemon = env.scene.getPlayerParty()[0];
+    const evolveSpy = vi.spyOn(pokemon, "evolve").mockImplementation(() => Promise.resolve());
+    vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([] as any);
+    const endSpy = vi.fn();
+    const unshiftSpy = vi.spyOn(env.scene.phaseManager, "unshiftNew");
+    env.scene.phaseManager.currentPhase = {
+      constructor: { name: "EvolutionPhase" },
+      pokemon,
+      evolution: {},
+      lastLevel: 1,
+      fusionSpeciesEvolved: false,
+      end: endSpy,
+    } as any;
+    env.step();
+    expect(evolveSpy).toHaveBeenCalled();
+    expect(unshiftSpy).toHaveBeenCalledWith("EndEvolutionPhase");
+    expect(endSpy).toHaveBeenCalled();
+  });
 });
 
 describe("rogue-env termination", () => {


### PR DESCRIPTION
## Summary
- automate evolution and egg phases in `RogueEnv`
- test automatic handling of evolution and egg phases

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849e60df3c08324a5ced864b3754e9c