### PR TITLE
Implement serialization version and extra Pokemon data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,8 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 - [x] Include detailed move information (power, type, remaining PP) in `SerializedState`.
 - [x] Capture held items, stat boosts and volatile statuses for both player and enemy.
 - [x] Expose arena features like hazards, terrain turns and wave index in a stable format.
-- Version the JSON schema so training data remains usable as the format evolves.
-- Include each Pokémon's ability and nature in `SerializedState` so replays can
+- [x] Version the JSON schema so training data remains usable as the format evolves.
+- [x] Include each Pokémon's ability and nature in `SerializedState` so replays can
   fully restore mid-run state.
 
 ## 4. Utility

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -4,3 +4,4 @@ export type { TransitionRecord } from "./transition-logger";
 export { computeStepReward, getRewardComponents, DEFAULT_WEIGHTS } from "./reward";
 export { replayTransitions, replayLogFile } from "./replay";
 export { benchmark } from "./benchmark";
+export { STATE_SCHEMA_VERSION } from "#app/utils/serialize";

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -10,6 +10,9 @@ import { getPlayerShopModifierTypeOptionsForWave } from "#app/modifier/modifier-
 import { HealShopCostModifier } from "#app/modifier/modifier";
 import { NumberHolder } from "#app/utils/common";
 
+/** Current version of the serialized state schema. */
+export const STATE_SCHEMA_VERSION = 1;
+
 export interface SerializedPokemon {
   species: number;
   level: number;
@@ -25,10 +28,16 @@ export interface SerializedPokemon {
   battlerTags: { type: BattlerTagType; turns: number }[];
   /** Whether this Pokémon is currently active on the field. */
   active: boolean;
+  /** Current ability identifier. */
+  ability: number;
+  /** Current nature identifier. */
+  nature: number;
   moves: { id: number; type: number; power: number; pp: number; maxPp: number }[];
 }
 
 export interface SerializedState {
+  /** Schema version for compatibility. */
+  schemaVersion: number;
   phase: string | undefined;
   turn: number;
   playerParty: SerializedPokemon[];
@@ -83,6 +92,8 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
     statStages: p.getStatStages(),
     battlerTags: p.summonData.tags.map(t => ({ type: t.tagType, turns: t.turnCount })),
     active: p.isActive(true),
+    ability: p.getAbility(true).id,
+    nature: p.getNature(),
     moves: p.getMoveset().map(m => ({
       id: m.moveId,
       type: m.getMove().type,
@@ -103,6 +114,7 @@ export default function serializeState(scene: BattleScene): SerializedState {
     shopOptions = getPlayerShopModifierTypeOptionsForWave(scene.currentBattle.waveIndex, holder.value).map(o => ({ id: o.type.id, cost: o.cost }));
   }
   return {
+    schemaVersion: STATE_SCHEMA_VERSION,
     phase: phaseName,
     turn: scene.currentBattle?.turn ?? 0,
     playerParty: scene.getPlayerParty().map(serializePokemon),

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -36,6 +36,9 @@ describe("rogue-env serialization", () => {
     expect(Array.isArray(state.playerParty[0].statStages)).toBe(true);
     expect(state.playerParty[0]).toHaveProperty("battlerTags");
     expect(Array.isArray(state.playerParty[0].battlerTags)).toBe(true);
+    expect(state.playerParty[0]).toHaveProperty("ability");
+    expect(state.playerParty[0]).toHaveProperty("nature");
+    expect(state).toHaveProperty("schemaVersion");
     expect(state).toHaveProperty("weather");
     expect(state).toHaveProperty("terrain");
     expect(state).toHaveProperty("terrainTurns");


### PR DESCRIPTION
## Summary
- include ability & nature in serialized state
- version the serialized state schema
- expose `STATE_SCHEMA_VERSION` via env index
- update rogue environment test expectations
- mark TODO items as complete

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6849ed1ccc0083249497cf2abbd33bd0