### PR TITLE
Add training script for headless env

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ npm run env:bench -- 1000
 
 This executes a given number of steps and reports the steps per second. `ROGUE_BENCH_STEPS` and `ROGUE_SEED` can also be provided as environment variables.
 
+To run a simple training session that records transitions, use:
+
+```bash
+npm run env:train -- 10000 my-log.json.gz
+```
+
+`ROGUE_TRAIN_STEPS`, `ROGUE_LOG_PATH` and `ROGUE_SEED` can also be provided as environment variables. The resulting log file is gzip compressed.
+
 
 ## 🪧 To Do
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ This file tracks outstanding work required to convert PokéRogue into a stable h
 - [x] Benchmark large batches of steps to identify remaining bottlenecks.
 
 ## 6. Integration and packaging
-- Provide an npm script or Dockerfile to run training sessions out of the box.
+- [x] Provide an npm script or Dockerfile to run training sessions out of the box.
 - Publish the headless environment as a versioned package for other projects.
 - Write concise documentation explaining how to embed the environment into external reinforcement learning pipelines.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "update-version:minor": "npm version minor --force --no-git-tag-version",
     "update-locales:remote": "git submodule update --progress --init --recursive --force --remote",
     "env:demo": "npx tsx scripts/rogue-env-demo.ts",
-    "env:bench": "npx tsx scripts/rogue-env-benchmark.ts"
+    "env:bench": "npx tsx scripts/rogue-env-benchmark.ts",
+    "env:train": "npx tsx scripts/rogue-env-train.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/scripts/rogue-env-train.ts
+++ b/scripts/rogue-env-train.ts
@@ -1,0 +1,20 @@
+import { RogueEnv, TransitionLogger } from "#env";
+
+const steps = parseInt(process.argv[2] ?? process.env.ROGUE_TRAIN_STEPS ?? "1000", 10);
+const output = process.argv[3] ?? process.env.ROGUE_LOG_PATH ?? "train-log.json";
+const seed = process.env.ROGUE_SEED;
+
+const env = new RogueEnv(seed);
+const logger = new TransitionLogger();
+env.logger = logger;
+
+env.reset();
+for (let i = 0; i < steps && !env.terminated; i++) {
+  const actions = env.getAvailableActions();
+  const action = actions[Math.floor(Math.random() * actions.length)];
+  env.step(action);
+}
+
+await logger.saveToFile(output, true);
+console.log(`Training log saved to ${output}`);
+


### PR DESCRIPTION
## Summary
- add `env:train` npm script and training example
- document how to run training sessions
- check off integration step in TODO

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh`
- `nvm use 22.14.0`
- `bash verify-setup.sh`
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6849efb6cb408324bb212eb7e487ee75