### PR TITLE
Remove shader imports from headless build

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1,6 +1,20 @@
 import Phaser from "phaser";
 import UI from "#app/ui/ui";
 import { headless } from "#app/global-vars/headless";
+
+let FieldSpritePipeline: typeof import("#app/pipelines/field-sprite").default;
+let SpritePipeline: typeof import("#app/pipelines/sprite").default;
+let InvertPostFX: typeof import("#app/pipelines/invert").default;
+
+if (!headless) {
+  ({ default: FieldSpritePipeline } = await import("#app/pipelines/field-sprite"));
+  ({ default: SpritePipeline } = await import("#app/pipelines/sprite"));
+  ({ default: InvertPostFX } = await import("#app/pipelines/invert"));
+} else {
+  FieldSpritePipeline = class extends Phaser.Renderer.WebGL.Pipelines.MultiPipeline {} as any;
+  SpritePipeline = FieldSpritePipeline as any;
+  InvertPostFX = class extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline {} as any;
+}
 import type Pokemon from "#app/field/pokemon";
 import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
 import type { PokemonSpeciesFilter } from "#app/data/pokemon-species";
@@ -83,8 +97,6 @@ import { BattleType } from "#enums/battle-type";
 import type { GameMode } from "#app/game-mode";
 import { getGameMode } from "#app/game-mode";
 import { GameModes } from "#enums/game-modes";
-import FieldSpritePipeline from "#app/pipelines/field-sprite";
-import SpritePipeline from "#app/pipelines/sprite";
 import PartyExpBar from "#app/ui/party-exp-bar";
 import type { TrainerSlot } from "./enums/trainer-slot";
 import { trainerConfigs } from "#app/data/trainers/trainer-config";
@@ -94,7 +106,6 @@ import type TrainerData from "#app/system/trainer-data";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
 import PokeballTray from "#app/ui/pokeball-tray";
-import InvertPostFX from "#app/pipelines/invert";
 import type { Achv } from "#app/system/achv";
 import { achvs, ModifierAchv, MoneyAchv } from "#app/system/achv";
 import type { Voucher } from "#app/system/voucher";
@@ -2638,6 +2649,9 @@ export default class BattleScene extends SceneBase {
   }
 
   toggleInvert(invert: boolean): void {
+    if (headless) {
+      return;
+    }
     if (invert) {
       this.cameras.main.setPostPipeline(InvertPostFX);
     } else {

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -1,8 +1,19 @@
 import { globalScene } from "#app/global-scene";
 import { TerrainType, getTerrainColor } from "../data/terrain";
 import { getCurrentTime } from "#app/utils/common";
-import fieldSpriteFragShader from "./glsl/fieldSpriteFragShader.frag?raw";
-import spriteVertShader from "./glsl/spriteShader.vert?raw";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const fieldSpriteFragShader = readFileSync(
+  join(dir, "glsl/fieldSpriteFragShader.frag"),
+  "utf8",
+);
+const spriteVertShader = readFileSync(
+  join(dir, "glsl/spriteShader.vert"),
+  "utf8",
+);
 
 export default class FieldSpritePipeline extends Phaser.Renderer.WebGL.Pipelines.MultiPipeline {
   constructor(game: Phaser.Game, config?: Phaser.Types.Renderer.WebGL.WebGLPipelineConfig) {

--- a/src/pipelines/invert.ts
+++ b/src/pipelines/invert.ts
@@ -1,5 +1,10 @@
 import type { Game } from "phaser";
-import fragShader from "./glsl/invert.frag?raw";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const fragShader = readFileSync(join(dir, "glsl/invert.frag"), "utf8");
 
 export default class InvertPostFX extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline {
   constructor(game: Game) {

--- a/src/pipelines/sprite.ts
+++ b/src/pipelines/sprite.ts
@@ -5,8 +5,19 @@ import Trainer from "#app/field/trainer";
 import { globalScene } from "#app/global-scene";
 import { rgbHexToRgba } from "#app/utils/common";
 import FieldSpritePipeline from "./field-sprite";
-import spriteFragShader from "./glsl/spriteFragShader.frag?raw";
-import spriteVertShader from "./glsl/spriteShader.vert?raw";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const spriteFragShader = readFileSync(
+  join(dir, "glsl/spriteFragShader.frag"),
+  "utf8",
+);
+const spriteVertShader = readFileSync(
+  join(dir, "glsl/spriteShader.vert"),
+  "utf8",
+);
 
 export default class SpritePipeline extends FieldSpritePipeline {
   private _tone: number[];


### PR DESCRIPTION
## Summary
- read shader source via `fs` so Node can load pipelines
- stub pipeline classes when running headless
- avoid screen inversion in headless mode

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684a09b4c08c83248015e349a3d2f699