### PR TITLE
Implement headless environment fixes

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -4,9 +4,18 @@ import type { SerializedState } from "#app/utils/serialize";
 import { tensor, train, layers, sequential, type LayersModel, dispose } from "@tensorflow/tfjs-node";
 
 function flattenState(state: SerializedState): number[] {
-  const player = state.playerParty[state.playerActive[0]];
-  const enemy = state.enemyParty[state.enemyActive[0]];
-  return [state.turn, state.wave, player.hp / player.maxHp, enemy.hp / enemy.maxHp, player.level, enemy.level];
+  const getMon = (party: any[], active: number[]): any | undefined => {
+    const idx = active?.[0];
+    if (idx === undefined || idx < 0 || idx >= party.length) return undefined;
+    return party[idx];
+  };
+  const player = getMon(state.playerParty, state.playerActive);
+  const enemy = getMon(state.enemyParty, state.enemyActive);
+  const playerHp = player ? player.hp / player.maxHp : 0;
+  const enemyHp = enemy ? enemy.hp / enemy.maxHp : 0;
+  const playerLevel = player?.level ?? 0;
+  const enemyLevel = enemy?.level ?? 0;
+  return [state.turn, state.wave, playerHp, enemyHp, playerLevel, enemyLevel];
 }
 
 const INPUT_SIZE = 6;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -449,11 +449,13 @@ export default class BattleScene extends SceneBase {
 
     this.load.setBaseURL();
 
-    this.spritePipeline = new SpritePipeline(this.game);
-    (this.renderer as Phaser.Renderer.WebGL.WebGLRenderer).pipelines.add("Sprite", this.spritePipeline);
+    if (!headless) {
+      this.spritePipeline = new SpritePipeline(this.game);
+      (this.renderer as Phaser.Renderer.WebGL.WebGLRenderer).pipelines.add("Sprite", this.spritePipeline);
 
-    this.fieldSpritePipeline = new FieldSpritePipeline(this.game);
-    (this.renderer as Phaser.Renderer.WebGL.WebGLRenderer).pipelines.add("FieldSprite", this.fieldSpritePipeline);
+      this.fieldSpritePipeline = new FieldSpritePipeline(this.game);
+      (this.renderer as Phaser.Renderer.WebGL.WebGLRenderer).pipelines.add("FieldSprite", this.fieldSpritePipeline);
+    }
 
     this.launchBattle();
   }
@@ -1217,16 +1219,16 @@ export default class BattleScene extends SceneBase {
     console.log("Seed:", this.seed);
     this.resetSeed();
 
-    this.biomeWaveText.setText(startingWave.toString());
-    this.biomeWaveText.setVisible(false);
+    this.biomeWaveText?.setText(startingWave.toString());
+    this.biomeWaveText?.setVisible(false);
 
     this.updateMoneyText();
-    this.moneyText.setVisible(false);
+    this.moneyText?.setVisible(false);
 
     this.updateScoreText();
-    this.scoreText.setVisible(false);
+    this.scoreText?.setVisible(false);
 
-    [this.luckLabelText, this.luckText].map(t => t.setVisible(false));
+    [this.luckLabelText, this.luckText].forEach(t => t?.setVisible(false));
 
     this.newArena(Overrides.STARTING_BIOME_OVERRIDE || BiomeId.TOWN);
 
@@ -1931,7 +1933,7 @@ export default class BattleScene extends SceneBase {
       teraColor: pokemon ? getTypeRgb(pokemon.getTeraType()) : undefined,
       isTerastallized: pokemon ? pokemon.isTerastallized : false,
     });
-    this.spriteSparkleHandler.add(sprite);
+    this.spriteSparkleHandler?.add(sprite);
     return sprite;
   }
 
@@ -2023,10 +2025,12 @@ export default class BattleScene extends SceneBase {
       return;
     }
     const formattedMoney = formatMoney(this.moneyFormat, this.money);
-    this.moneyText.setText(i18next.t("battleScene:moneyOwned", { formattedMoney }));
-    this.fieldUI.moveAbove(this.moneyText, this.luckText);
-    if (forceVisible) {
-      this.moneyText.setVisible(true);
+    this.moneyText?.setText(i18next.t("battleScene:moneyOwned", { formattedMoney }));
+    if (this.moneyText) {
+      this.fieldUI.moveAbove(this.moneyText, this.luckText);
+      if (forceVisible) {
+        this.moneyText.setVisible(true);
+      }
     }
   }
 
@@ -2047,8 +2051,8 @@ export default class BattleScene extends SceneBase {
   }
 
   updateScoreText(): void {
-    this.scoreText.setText(`Score: ${this.score.toString()}`);
-    this.scoreText.setVisible(this.gameMode.isDaily);
+    this.scoreText?.setText(`Score: ${this.score.toString()}`);
+    this.scoreText?.setVisible(this.gameMode.isDaily);
   }
 
   /**

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -21,6 +21,7 @@ import { initMoves } from "#app/data/moves/move";
 import { initPokemonForms } from "#app/data/pokemon-forms";
 import { initSpecies } from "#app/data/pokemon-species";
 import { initAbilities } from "#app/data/abilities/ability";
+import TextInterceptor from "#test/testUtils/TextInterceptor";
 
 export enum RogueAction {
   /** Use the first move in the active Pokémon's moveset. */
@@ -166,6 +167,8 @@ export default class RogueEnv {
     this.scene = new BattleScene();
     this.wrapper = new GameWrapper(this.game, true);
     this.wrapper.setScene(this.scene);
+    // Attach a simple text interceptor so UI text calls do not fail
+    new TextInterceptor(this.scene);
     const originalPush = this.scene.phaseManager.pushNew.bind(this.scene.phaseManager);
     this.scene.phaseManager.pushNew = (phase: string, ...args: any[]) => {
       if (phase === "LoginPhase" || phase === "TitlePhase") {
@@ -368,8 +371,8 @@ export default class RogueEnv {
     const phase = this.scene.phaseManager.getCurrentPhase();
     const actions: RogueAction[] = [];
     if (phase instanceof CommandPhase) {
-      const pokemon = phase.getPokemon();
-      const moves = pokemon.getMoveset();
+      const pokemon = phase.getPokemon?.();
+      const moves = pokemon?.getMoveset?.() ?? [];
       for (let i = 0; i < Math.min(4, moves.length); i++) {
         if (pokemon.trySelectMove(i)) {
           actions.push(RogueAction.FIGHT_1 + i);
@@ -428,7 +431,7 @@ export default class RogueEnv {
       }
     } else if (phase?.constructor.name === "LearnMovePhase") {
       const pokemon = phase.getPokemon?.() as any;
-      if (pokemon?.getMoveset().length >= 4) {
+      if (pokemon?.getMoveset?.().length >= 4) {
         actions.push(
           RogueAction.LEARN_REJECT,
           RogueAction.LEARN_REPLACE_1,

--- a/src/global-vars/headless.ts
+++ b/src/global-vars/headless.ts
@@ -1,2 +1,3 @@
 export const headless =
-  typeof import.meta !== "undefined" && import.meta.env && import.meta.env.VITE_HEADLESS === "1";
+  (typeof import.meta !== "undefined" && (import.meta as any).env && (import.meta as any).env.VITE_HEADLESS === "1") ||
+  process.env.VITE_HEADLESS === "1";

--- a/src/plugins/api/api-base.ts
+++ b/src/plugins/api/api-base.ts
@@ -69,7 +69,7 @@ export abstract class ApiBase {
       "Content-Type": config.headers?.["Content-Type"] ?? "application/json",
     };
 
-    if (import.meta.env.DEV) {
+    if ((import.meta as any).env?.DEV) {
       console.log(`Sending ${config.method ?? "GET"} request to: `, this.base + path, config);
     }
 


### PR DESCRIPTION
## Summary
- handle undefined values in the DQN script
- set up TextInterceptor when building `RogueEnv`
- support `process.env.VITE_HEADLESS` for headless mode
- guard optional UI features when headless
- avoid crashing when logging request info

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_684a310da2f483248023cfe211cf49ae