### PR TITLE
Fix headless training

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -81,6 +81,7 @@ import {
   PokemonHeldItemModifierType,
 } from "#app/modifier/modifier-type";
 import AbilityBar from "#app/ui/ability-bar";
+import StubAbilityBar from "#app/ui/stub-ability-bar";
 import {
   applyAbAttrs,
   applyPostBattleInitAbAttrs,
@@ -539,7 +540,6 @@ export default class BattleScene extends SceneBase {
     this.modifiers = [];
     this.enemyModifiers = [];
 
-    if (!headless) {
       this.modifierBar = new ModifierBar();
       this.modifierBar.setName("modifier-bar");
       this.add.existing(this.modifierBar);
@@ -566,11 +566,14 @@ export default class BattleScene extends SceneBase {
 
       this.fieldUI.add(this.pbTray);
       this.fieldUI.add(this.pbTrayEnemy);
-
-      this.abilityBar = new AbilityBar();
-      this.abilityBar.setName("ability-bar");
-      this.abilityBar.setup();
-      this.fieldUI.add(this.abilityBar);
+      if (!headless) {
+        this.abilityBar = new AbilityBar();
+        this.abilityBar.setName("ability-bar");
+        this.abilityBar.setup();
+        this.fieldUI.add(this.abilityBar);
+      } else {
+        this.abilityBar = new StubAbilityBar() as unknown as AbilityBar;
+      }
 
       this.partyExpBar = new PartyExpBar();
       this.partyExpBar.setName("party-exp-bar");
@@ -638,7 +641,6 @@ export default class BattleScene extends SceneBase {
       this.pokemonInfoContainer.setup();
 
       this.fieldUI.add(this.pokemonInfoContainer);
-    }
 
     this.party = [];
 
@@ -703,9 +705,7 @@ export default class BattleScene extends SceneBase {
 
     this.ui = ui;
 
-    if (!headless) {
-      ui.setup();
-    }
+    ui.setup();
 
     const defaultMoves = [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE];
 

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -329,7 +329,10 @@ export class CommandPhase extends FieldPhase {
                 cursor: cursor,
               };
               globalScene.currentBattle.turnCommands[this.fieldIndex]!.targets = targets;
-              if (this.fieldIndex) {
+              if (
+                this.fieldIndex &&
+                globalScene.currentBattle.turnCommands[this.fieldIndex - 1]
+              ) {
                 globalScene.currentBattle.turnCommands[this.fieldIndex - 1]!.skip = true;
               }
               success = true;
@@ -384,7 +387,11 @@ export class CommandPhase extends FieldPhase {
               ? { command: Command.POKEMON, cursor: cursor, args: args }
               : { command: Command.RUN };
             success = true;
-            if (!isSwitch && this.fieldIndex) {
+            if (
+              !isSwitch &&
+              this.fieldIndex &&
+              currentBattle.turnCommands[this.fieldIndex - 1]
+            ) {
               currentBattle.turnCommands[this.fieldIndex - 1]!.skip = true;
             }
           } else if (trappedAbMessages.length > 0) {

--- a/src/ui/stub-ability-bar.ts
+++ b/src/ui/stub-ability-bar.ts
@@ -1,0 +1,12 @@
+export default class StubAbilityBar {
+  setName(name: string): void {}
+  setup(): void {}
+  hide(): Promise<void> { return Promise.resolve(); }
+  showAbility(
+    pokemonName: string,
+    abilityName: string,
+    passive = false,
+    player = true,
+  ): Promise<void> { return Promise.resolve(); }
+  isVisible(): boolean { return false; }
+}


### PR DESCRIPTION
## Summary
- call `ui.setup` in headless mode so UI containers exist
- drop headless check around UI creation and supply stub ability bar when headless
- guard against missing turn command entries during BALL/RUN actions
- add new `StubAbilityBar` for headless use

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `timeout 15 sh -c 'VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts'`

------
https://chatgpt.com/codex/tasks/task_e_684a34f50dfc832499066c009af9083c