### PR TITLE
Fix headless training

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2011,6 +2011,10 @@ export default class BattleScene extends SceneBase {
   }
 
   updateBiomeWaveText(): void {
+    if (!this.biomeWaveText) {
+      return;
+    }
+
     const isBoss = !(this.currentBattle.waveIndex % 10);
     const biomeString: string = getBiomeName(this.arena.biomeType);
     this.fieldUI.moveAbove(this.biomeWaveText, this.luckText);

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -493,7 +493,7 @@ export class PhaseManager {
    * Hides the ability bar if it is currently visible
    */
   public hideAbilityBar(): void {
-    if (globalScene.abilityBar.isVisible()) {
+    if (globalScene.abilityBar && globalScene.abilityBar.isVisible()) {
       this.unshiftPhase(new HideAbilityPhase());
     }
   }

--- a/src/phases/hide-ability-phase.ts
+++ b/src/phases/hide-ability-phase.ts
@@ -6,6 +6,11 @@ export class HideAbilityPhase extends Phase {
   start() {
     super.start();
 
+    if (!globalScene.abilityBar) {
+      this.end();
+      return;
+    }
+
     globalScene.abilityBar.hide().then(() => {
       this.end();
     });

--- a/src/phases/show-ability-phase.ts
+++ b/src/phases/show-ability-phase.ts
@@ -34,7 +34,7 @@ export class ShowAbilityPhase extends PokemonPhase {
     }
 
     // If the bar is already out, hide it before showing the new one
-    if (globalScene.abilityBar.isVisible()) {
+    if (globalScene.abilityBar && globalScene.abilityBar.isVisible()) {
       globalScene.phaseManager.unshiftNew("HideAbilityPhase");
       globalScene.phaseManager.unshiftNew("ShowAbilityPhase", this.battlerIndex, this.passive);
       return this.end();
@@ -47,6 +47,10 @@ export class ShowAbilityPhase extends PokemonPhase {
       globalScene.currentBattle.lastEnemyInvolved = pokemon.getBattlerIndex() % 2;
     } else {
       globalScene.currentBattle.lastPlayerInvolved = pokemon.getBattlerIndex() % 2;
+    }
+
+    if (!globalScene.abilityBar) {
+      return this.end();
     }
 
     globalScene.abilityBar.showAbility(this.pokemonName, this.abilityName, this.passive, this.player).then(() => {

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import type { BattlerIndex } from "#enums/battler-index";
 import {
   applyAbAttrs,
@@ -257,7 +258,7 @@ export class StatStageChangePhase extends PokemonPhase {
       handleTutorial(Tutorial.Stat_Change).then(() => super.end());
     };
 
-    if (relLevels.filter(l => l).length && globalScene.moveAnimations) {
+    if (!headless && relLevels.filter(l => l).length && globalScene.moveAnimations && pokemon.maskSprite) {
       pokemon.enableMask();
       const pokemonMaskSprite = pokemon.maskSprite;
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -320,7 +320,7 @@ export class GameData {
 
   public saveSystem(): Promise<boolean> {
     return new Promise<boolean>(resolve => {
-      globalScene.ui.savingIcon.show();
+      globalScene.ui?.savingIcon?.show();
       const data = this.getSystemSaveData();
 
       const maxIntAttrValue = 0x80000000;
@@ -332,7 +332,7 @@ export class GameData {
 
       if (!bypassLogin) {
         pokerogueApi.savedata.system.update({ clientSessionId }, systemData).then(error => {
-          globalScene.ui.savingIcon.hide();
+          globalScene.ui?.savingIcon?.hide();
           if (error) {
             if (error.startsWith("session out of date")) {
               globalScene.phaseManager.clearPhaseQueue();
@@ -344,7 +344,7 @@ export class GameData {
           resolve(true);
         });
       } else {
-        globalScene.ui.savingIcon.hide();
+        globalScene.ui?.savingIcon?.hide();
 
         resolve(true);
       }
@@ -1318,7 +1318,7 @@ export class GameData {
         if (success !== null && !success) {
           return resolve(false);
         }
-        if (sync) {
+        if (sync && globalScene.ui?.savingIcon) {
           globalScene.ui.savingIcon.show();
         }
         const sessionData = useCachedSession
@@ -1361,10 +1361,10 @@ export class GameData {
 
         if (!bypassLogin && sync) {
           pokerogueApi.savedata.updateAll(request).then(error => {
-            if (sync) {
-              globalScene.lastSavePlayTime = 0;
-              globalScene.ui.savingIcon.hide();
-            }
+              if (sync && globalScene.ui?.savingIcon) {
+                globalScene.lastSavePlayTime = 0;
+                globalScene.ui.savingIcon.hide();
+              }
             if (error) {
               if (error.startsWith("session out of date")) {
                 globalScene.phaseManager.clearPhaseQueue();
@@ -1376,10 +1376,10 @@ export class GameData {
             resolve(true);
           });
         } else {
-          this.verify().then(success => {
-            globalScene.ui.savingIcon.hide();
-            resolve(success);
-          });
+            this.verify().then(success => {
+              globalScene.ui?.savingIcon?.hide();
+              resolve(success);
+            });
         }
       });
     });

--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import { addBBCodeTextObject, addTextObject, getTextColor, TextStyle } from "./text";
 import { UiMode } from "#enums/ui-mode";
 import MessageUiHandler from "./message-ui-handler";
@@ -146,9 +147,11 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
   show(args: any[]): boolean {
     super.show(args);
 
-    this.commandWindow.setVisible(false);
-    this.movesWindowContainer.setVisible(false);
-    this.message.setWordWrapWidth(this.wordWrapWidth);
+    if (!headless) {
+      this.commandWindow.setVisible(false);
+      this.movesWindowContainer.setVisible(false);
+      this.message.setWordWrapWidth(this.wordWrapWidth);
+    }
 
     return true;
   }

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -7,6 +7,7 @@ import { Button } from "#enums/buttons";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { globalScene } from "#app/global-scene";
+import { headless } from "#app/global-vars/headless";
 import { TerastallizeAccessModifier } from "#app/modifier/modifier";
 import { PokemonType } from "#enums/pokemon-type";
 import { getTypeRgb } from "#app/data/type";
@@ -63,6 +64,10 @@ export default class CommandUiHandler extends UiHandler {
     super.show(args);
 
     this.fieldIndex = args.length ? (args[0] as number) : 0;
+
+    if (headless) {
+      return true;
+    }
 
     this.commandsContainer.setVisible(true);
 
@@ -225,16 +230,18 @@ export default class CommandUiHandler extends UiHandler {
       }
     }
 
-    if (!this.cursorObj) {
+    if (!this.cursorObj && this.commandsContainer) {
       this.cursorObj = globalScene.add.image(0, 0, "cursor");
       this.commandsContainer.add(this.cursorObj);
     }
 
-    if (cursor === Command.TERA) {
-      this.cursorObj.setVisible(false);
-    } else {
-      this.cursorObj.setPosition(-5 + (cursor % 2 === 1 ? 56 : 0), 8 + (cursor >= 2 ? 16 : 0));
-      this.cursorObj.setVisible(true);
+    if (this.cursorObj) {
+      if (cursor === Command.TERA) {
+        this.cursorObj.setVisible(false);
+      } else {
+        this.cursorObj.setPosition(-5 + (cursor % 2 === 1 ? 56 : 0), 8 + (cursor >= 2 ? 16 : 0));
+        this.cursorObj.setVisible(true);
+      }
     }
 
     return changed;
@@ -242,9 +249,10 @@ export default class CommandUiHandler extends UiHandler {
 
   clear(): void {
     super.clear();
-    this.getUi().getMessageHandler().commandWindow.setVisible(false);
-    this.commandsContainer.setVisible(false);
-    this.getUi().getMessageHandler().clearText();
+    const mh = this.getUi().getMessageHandler?.();
+    mh?.commandWindow?.setVisible(false);
+    this.commandsContainer?.setVisible(false);
+    mh?.clearText?.();
     this.eraseCursor();
   }
 

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -265,7 +265,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
   }
 
   clearText() {
-    this.message.setText("");
+    this.message?.setText("");
     this.pendingPrompt = false;
   }
 


### PR DESCRIPTION
## Summary
- fix ability bar lookups during headless mode
- guard UI code when running headless
- avoid crashes when saving or animating in headless mode
- handle optional message elements in message UI

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684a34f95d188324a0ff3c1073da0b77