### PR TITLE
Silence asset warnings

### DIFF
--- a/scripts/headless-globals.ts
+++ b/scripts/headless-globals.ts
@@ -63,6 +63,30 @@ if (typeof globalThis.window === 'undefined') {
       },
     } as any;
   }
+
+  // Filter noisy asset warnings when running in headless mode
+  const assetWarningPatterns = [
+    /Texture ".*" not found/i,
+    /variant icon does not exist/i,
+  ];
+
+  const originalWarn = console.warn;
+  console.warn = (...args: any[]) => {
+    const msg = args[0];
+    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
+      return;
+    }
+    originalWarn(...args);
+  };
+
+  const originalLog = console.log;
+  console.log = (...args: any[]) => {
+    const msg = args[0];
+    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
+      return;
+    }
+    originalLog(...args);
+  };
 }
 
 export {};

--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -99,6 +99,9 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     if (this.optionSelectText) {
       if (this.optionSelectText instanceof BBCodeText) {
         try {
+          // Prevent errors if the underlying texture does not expose a destroy
+          // method when running headless
+          (this.optionSelectText as any).texture = null;
           this.optionSelectText.destroy();
         } catch (error) {
           console.error("Error while destroying optionSelectText:", error);


### PR DESCRIPTION
## Summary
- suppress missing texture logs in headless environment
- guard against BBCodeText destroy error

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684a39499bb083249de0a75f0d325396