### PR TITLE
Improve DQN training logging

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -1,6 +1,6 @@
 import "./headless-globals";
-import { RogueEnv, type RogueAction } from "#env";
-import type { SerializedState } from "#app/utils/serialize";
+import { RogueEnv, RogueAction } from "#env";
+import type { SerializedState, SerializedPokemon } from "#app/utils/serialize";
 import { tensor, train, layers, sequential, type LayersModel, dispose } from "@tensorflow/tfjs-node";
 
 function flattenState(state: SerializedState): number[] {
@@ -20,6 +20,30 @@ function flattenState(state: SerializedState): number[] {
 
 const INPUT_SIZE = 6;
 const ACTION_COUNT = 42; // total actions in RogueAction enum
+
+function summarizeMon(p: SerializedPokemon) {
+  return {
+    species: p.species,
+    level: p.level,
+    hp: p.hp,
+    maxHp: p.maxHp,
+    status: p.status,
+  };
+}
+
+export function logSerializedState(state: SerializedState, action: RogueAction) {
+  const summary = {
+    phase: state.phase,
+    turn: state.turn,
+    wave: state.wave,
+    player: state.playerParty.map(summarizeMon),
+    enemy: state.enemyParty.map(summarizeMon),
+    playerActive: state.playerActive,
+    enemyActive: state.enemyActive,
+    action: RogueAction[action],
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
 
 class DQNAgent {
   private model: LayersModel;
@@ -101,12 +125,15 @@ async function runTraining(episodes = 10, maxSteps = 200) {
   const agent = new DQNAgent();
   for (let ep = 0; ep < episodes; ep++) {
     env.reset();
-    let state = flattenState(env.getState());
+    let serialized = env.getState();
+    let state = flattenState(serialized);
     for (let t = 0; t < maxSteps && !env.terminated; t++) {
       const available = env.getAvailableActions();
       const action = agent.act(state, available);
+      logSerializedState(serialized, action as RogueAction);
       const reward = env.step(action as RogueAction);
-      const nextState = flattenState(env.getState());
+      serialized = env.getState();
+      const nextState = flattenState(serialized);
       agent.remember(state, action, reward, nextState, env.terminated);
       state = nextState;
       await agent.replay();
@@ -116,4 +143,8 @@ async function runTraining(episodes = 10, maxSteps = 200) {
   await agent.model.save("file://dqn-model");
 }
 
-runTraining().catch(err => console.error(err));
+export { runTraining };
+
+if (import.meta.main) {
+  runTraining().catch(err => console.error(err));
+}

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -516,3 +516,19 @@ describe("benchmark utility", () => {
     vi.resetModules();
   });
 });
+
+describe("dqn script logging", () => {
+  it("should log state and action", async () => {
+    const env = new RogueEnv();
+    env.reset();
+    const state = env.getState();
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (msg: any) => { logs.push(String(msg)); };
+    const { logSerializedState } = await import("../scripts/rogue-env-dqn.ts");
+    logSerializedState(state, RogueAction.FIGHT_1);
+    console.log = orig;
+    const entry = logs.find(l => l.trim().startsWith("{"));
+    expect(entry).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- extend `rogue-env-dqn.ts` with a helper to log serialized battle state
- log the state and chosen action during training
- expose `runTraining` for reuse and update script entry point
- add unit test covering logging helper

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684a41b3ddb88324b8848b4c2a30ce33