### PR TITLE
Add DQN logging and configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ For a more advanced example using a neural network agent, see the [Reinforcement
 ```bash
 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts
 ```
+The script accepts optional arguments for episodes, steps, model directory and log file:
+
+```bash
+VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 50 500 my-model my-log.json.gz
+```
+Environment variables `ROGUE_EPISODES`, `ROGUE_MAX_STEPS`, `ROGUE_MODEL_PATH` and `ROGUE_LOG_PATH` may be used instead of arguments.
+If the log filename ends with `.gz` it will be gzip compressed.
 
 
 

--- a/docs/rl-guide.md
+++ b/docs/rl-guide.md
@@ -23,8 +23,18 @@ Execute it with:
 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts
 ```
 
-The script saves the trained model to the `dqn-model` directory. Adjust the
-`episodes` and `maxSteps` parameters inside the file to control training length.
+Optional arguments let you set the episode count, steps per episode, model output
+directory and log file:
+
+```bash
+VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 50 500 my-model my-log.json.gz
+```
+
+Environment variables `ROGUE_EPISODES`, `ROGUE_MAX_STEPS`, `ROGUE_MODEL_PATH` and
+`ROGUE_LOG_PATH` may also be provided.
+
+The model directory defaults to `dqn-model`. When a log path is supplied the
+training transitions are saved (gzip compressed if the filename ends with `.gz`).
 
 ## 3. Writing Custom Agents
 

--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -1,6 +1,7 @@
 import "./headless-globals";
-import { RogueEnv, type RogueAction } from "#env";
+import { RogueEnv, type RogueAction, TransitionLogger } from "#env";
 import type { SerializedState } from "#app/utils/serialize";
+import { resolve } from "node:path";
 import { tensor, train, layers, sequential, type LayersModel, dispose } from "@tensorflow/tfjs-node";
 
 function flattenState(state: SerializedState): number[] {
@@ -96,8 +97,10 @@ class DQNAgent {
   }
 }
 
-async function runTraining(episodes = 10, maxSteps = 200) {
+async function runTraining(episodes = 10, maxSteps = 200, modelPath = "dqn-model", logPath?: string) {
   const env = new RogueEnv();
+  const logger = new TransitionLogger();
+  env.logger = logger;
   const agent = new DQNAgent();
   for (let ep = 0; ep < episodes; ep++) {
     env.reset();
@@ -113,7 +116,20 @@ async function runTraining(episodes = 10, maxSteps = 200) {
     }
     console.log(`Episode ${ep + 1} complete`);
   }
-  await agent.model.save("file://dqn-model");
+  const modelDir = resolve(modelPath);
+  await agent.model.save(`file://${modelDir}`);
+  console.log(`Model saved to ${modelDir}`);
+  if (logPath) {
+    const logFile = resolve(logPath);
+    const compress = logFile.endsWith('.gz');
+    await logger.saveToFile(logFile, compress);
+    console.log(`Training log saved to ${logFile}`);
+  }
 }
 
-runTraining().catch(err => console.error(err));
+const episodes = Number.parseInt(process.argv[2] ?? process.env.ROGUE_EPISODES ?? "10", 10);
+const maxSteps = Number.parseInt(process.argv[3] ?? process.env.ROGUE_MAX_STEPS ?? "200", 10);
+const modelPath = process.argv[4] ?? process.env.ROGUE_MODEL_PATH ?? "dqn-model";
+const logPath = process.argv[5] ?? process.env.ROGUE_LOG_PATH;
+
+runTraining(episodes, maxSteps, modelPath, logPath).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- support saving logs and custom model directories in `rogue-env-dqn.ts`
- document the new options in README and rl-guide
- make log compression optional in DQN script and clarify docs

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 1 5 my-model my-log.json.gz`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 1 5 my-model my-log.json`


------
https://chatgpt.com/codex/tasks/task_e_684a490265fc832499eda6feb4892fb7