### PR TITLE
Fix headless training crash

### DIFF
--- a/scripts/headless-globals.ts
+++ b/scripts/headless-globals.ts
@@ -70,23 +70,28 @@ if (typeof globalThis.window === 'undefined') {
     /variant icon does not exist/i,
   ];
 
-  const originalWarn = console.warn;
-  console.warn = (...args: any[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
-      return;
-    }
-    originalWarn(...args);
-  };
+  const patched = (console as any).__headlessPatched;
+  if (!patched) {
+    const originalWarn = console.warn.bind(console);
+    const originalLog = console.log.bind(console);
+    (console as any).__headlessPatched = { warn: originalWarn, log: originalLog };
 
-  const originalLog = console.log;
-  console.log = (...args: any[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
-      return;
-    }
-    originalLog(...args);
-  };
+    console.warn = (...args: any[]) => {
+      const msg = args[0];
+      if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
+        return;
+      }
+      originalWarn(...args);
+    };
+
+    console.log = (...args: any[]) => {
+      const msg = args[0];
+      if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
+        return;
+      }
+      originalLog(...args);
+    };
+  }
 }
 
 export {};

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -372,6 +372,10 @@ export class EncounterPhase extends BattlePhase {
   getEncounterMessage(): string {
     const enemyField = globalScene.getEnemyField();
 
+    if (enemyField.length === 0) {
+      return "";
+    }
+
     if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
       return i18next.t("battle:bossAppeared", {
         bossName: getPokemonNameWithAffix(enemyField[0]),
@@ -412,8 +416,9 @@ export class EncounterPhase extends BattlePhase {
         }
       }
       globalScene.updateFieldScale();
-      if (showEncounterMessage) {
-        globalScene.ui.showText(this.getEncounterMessage(), null, () => this.end(), 1500);
+      const message = this.getEncounterMessage();
+      if (showEncounterMessage && message) {
+        globalScene.ui.showText(message, null, () => this.end(), 1500);
       } else {
         this.end();
       }


### PR DESCRIPTION
## Summary
- avoid crashes from empty enemy arrays in EncounterPhase
- guard console patching in headless globals to prevent recursion

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 10 my-model my-log.json.gz`

------
https://chatgpt.com/codex/tasks/task_e_684ac5eedcb4832492e32805e4553e1b