### PR TITLE
Fix headless training crash

### DIFF
--- a/scripts/headless-globals.ts
+++ b/scripts/headless-globals.ts
@@ -70,23 +70,20 @@ if (typeof globalThis.window === 'undefined') {
     /variant icon does not exist/i,
   ];
 
-  const originalWarn = console.warn;
-  console.warn = (...args: any[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
-      return;
-    }
-    originalWarn(...args);
-  };
+  const patched = (console as any).__headlessPatched;
+  if (!patched) {
+    const originalWarn = console.warn.bind(console);
+    (console as any).__headlessPatched = { warn: originalWarn };
 
-  const originalLog = console.log;
-  console.log = (...args: any[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
-      return;
-    }
-    originalLog(...args);
-  };
+    console.warn = (...args: any[]) => {
+      const msg = args[0];
+      if (typeof msg === 'string' && assetWarningPatterns.some(p => p.test(msg))) {
+        return;
+      }
+      originalWarn(...args);
+    };
+
+  }
 }
 
 export {};

--- a/src/data/moves/pokemon-move.ts
+++ b/src/data/moves/pokemon-move.ts
@@ -47,7 +47,7 @@ export class PokemonMove {
    * @returns `true` if the move can be selected and used by the Pokemon, otherwise `false`.
    */
   isUsable(pokemon: Pokemon, ignorePp = false, ignoreRestrictionTags = false): boolean {
-    if (this.moveId && !ignoreRestrictionTags && pokemon.isMoveRestricted(this.moveId, pokemon)) {
+    if (this.moveId && !ignoreRestrictionTags && pokemon.isMoveRestricted(this.moveId)) {
       return false;
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1206,14 +1206,20 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param animConfig {@linkcode String} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
    * @returns true if the sprite was able to be animated
    */
-  tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
+  tryPlaySprite(
+    sprite: Phaser.GameObjects.Sprite | null | undefined,
+    tintSprite: Phaser.GameObjects.Sprite | null | undefined,
+    key: string,
+  ): boolean {
+    if (!sprite || !tintSprite) {
+      return false;
+    }
     // Catch errors when trying to play an animation that doesn't exist
     try {
       sprite.play(key);
       tintSprite.play(key);
     } catch (error: unknown) {
       console.error(`Couldn't play animation for '${key}'!\nIs the image for this Pokemon missing?\n`, error);
-
       return false;
     }
 
@@ -1221,7 +1227,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   playAnim(): void {
-    this.tryPlaySprite(this.getSprite(), this.getTintSprite()!, this.getBattleSpriteKey()); // TODO: is the bang correct?
+    this.tryPlaySprite(this.getSprite(), this.getTintSprite(), this.getBattleSpriteKey());
   }
 
   getFieldPositionOffset(): [number, number] {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -3687,7 +3687,7 @@ function getNewModifierTypeOption(
     }
   }
 
-  if (index === undefined) {
+  if (index === undefined || index >= pool[tier].length) {
     return null;
   }
 

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -372,6 +372,10 @@ export class EncounterPhase extends BattlePhase {
   getEncounterMessage(): string {
     const enemyField = globalScene.getEnemyField();
 
+    if (enemyField.length === 0) {
+      return "";
+    }
+
     if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
       return i18next.t("battle:bossAppeared", {
         bossName: getPokemonNameWithAffix(enemyField[0]),
@@ -412,8 +416,9 @@ export class EncounterPhase extends BattlePhase {
         }
       }
       globalScene.updateFieldScale();
-      if (showEncounterMessage) {
-        globalScene.ui.showText(this.getEncounterMessage(), null, () => this.end(), 1500);
+      const message = this.getEncounterMessage();
+      if (showEncounterMessage && message) {
+        globalScene.ui.showText(message, null, () => this.end(), 1500);
       } else {
         this.end();
       }


### PR DESCRIPTION
## Summary
- avoid patching console.log in headless globals
- skip playing animations when sprites are missing
- guard against out-of-range indexes when generating modifiers
- check move restrictions without passing duplicate user

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 10 modeltmp logtmp.json.gz`

------
https://chatgpt.com/codex/tasks/task_e_684ac5eedcb4832492e32805e4553e1b