### PR TITLE
Fix RL training crashes and add seed option

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -97,8 +97,14 @@ class DQNAgent {
   }
 }
 
-async function runTraining(episodes = 10, maxSteps = 200, modelPath = "dqn-model", logPath?: string) {
-  const env = new RogueEnv();
+async function runTraining(
+  episodes = 10,
+  maxSteps = 200,
+  modelPath = "dqn-model",
+  logPath?: string,
+  seed?: string,
+) {
+  const env = new RogueEnv(seed);
   const logger = new TransitionLogger();
   env.logger = logger;
   const agent = new DQNAgent();
@@ -131,5 +137,6 @@ const episodes = Number.parseInt(process.argv[2] ?? process.env.ROGUE_EPISODES ?
 const maxSteps = Number.parseInt(process.argv[3] ?? process.env.ROGUE_MAX_STEPS ?? "200", 10);
 const modelPath = process.argv[4] ?? process.env.ROGUE_MODEL_PATH ?? "dqn-model";
 const logPath = process.argv[5] ?? process.env.ROGUE_LOG_PATH;
+const seed = process.argv[6] ?? process.env.ROGUE_SEED;
 
-runTraining(episodes, maxSteps, modelPath, logPath).catch(err => console.error(err));
+runTraining(episodes, maxSteps, modelPath, logPath, seed).catch(err => console.error(err));

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -439,7 +439,6 @@ export default class Battle {
       Phaser.Math.RND.state(this.battleSeedState);
     } else {
       Phaser.Math.RND.sow([shiftCharCodes(this.battleSeed, this.turn << 6)]);
-      console.log("Battle Seed:", this.battleSeed);
     }
     globalScene.rngCounter = this.rngCounter++;
     globalScene.rngSeedOverride = this.battleSeed;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6353,7 +6353,7 @@ export class EnemyPokemon extends Pokemon {
             moveScores[m] = moveScore;
           }
 
-          console.log(moveScores);
+
 
           // Sort the move pool in decreasing order of move score
           const sortedMovePool = movePool.slice(0);
@@ -6384,12 +6384,7 @@ export class EnemyPokemon extends Pokemon {
               r++;
             }
           }
-          console.log(
-            movePool.map(m => m.getName()),
-            moveScores,
-            r,
-            sortedMovePool.map(m => m.getName()),
-          );
+          // Log statements removed for headless execution stability
           return { move: sortedMovePool[r]!.moveId, targets: moveTargets[sortedMovePool[r]!.moveId] };
         }
       }

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -350,7 +350,7 @@ export class PhaseManager {
     }
 
     if (this.currentPhase) {
-      console.log(`%cStart Phase ${this.currentPhase.constructor.name}`, "color:green;");
+      // Debug logging removed for headless execution
       this.currentPhase.start();
     }
   }
@@ -362,7 +362,7 @@ export class PhaseManager {
 
     this.standbyPhase = this.currentPhase;
     this.currentPhase = phase;
-    console.log(`%cStart Phase ${phase.constructor.name}`, "color:green;");
+    // Debug logging removed for headless execution
     phase.start();
 
     return true;

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -136,7 +136,6 @@ export class MovePhase extends BattlePhase {
   public start(): void {
     super.start();
 
-    console.log(MoveId[this.move.moveId]);
 
     // Check if move is unusable (e.g. because it's out of PP due to a mid-turn Spite).
     if (!this.canMove(true)) {

--- a/test/testUtils/TextInterceptor.ts
+++ b/test/testUtils/TextInterceptor.ts
@@ -17,7 +17,7 @@ export default class TextInterceptor {
     _prompt?: boolean,
     _promptDelay?: number,
   ): void {
-    console.log(text);
+    // Suppress console output during headless execution
     this.logs.push(text);
   }
 
@@ -29,7 +29,7 @@ export default class TextInterceptor {
     _callbackDelay?: number,
     _promptDelay?: number,
   ): void {
-    console.log(name, text);
+    // Suppress console output during headless execution
     this.logs.push(name, text);
   }
 


### PR DESCRIPTION
## Summary
- remove verbose console logs that caused stack overflows
- allow specifying a seed in `rogue-env-dqn.ts`
- silence text interceptor outputs

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `ROGUE_SEED=bar VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 10 model2 log2.json.gz`


------
https://chatgpt.com/codex/tasks/task_e_684add1ae62083249322e8fe58210231