### PR TITLE
Fix training recursion issue

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -196,6 +196,9 @@ export default class RogueEnv {
     this.scene.phaseManager.clearAllPhases();
     this.scene.phaseManager.pushNew("TurnInitPhase");
     this.scene.phaseManager.shiftPhase();
+    while (this.scene.phaseManager.hasQueuedShift()) {
+      this.scene.phaseManager.shiftPhase();
+    }
   }
 
   /**
@@ -323,10 +326,16 @@ export default class RogueEnv {
       }
 
       this.scene.phaseManager.shiftPhase();
+      while (this.scene.phaseManager.hasQueuedShift()) {
+        this.scene.phaseManager.shiftPhase();
+      }
       let phase = this.scene.phaseManager.getCurrentPhase();
       let safety = 0;
       while (phase && !(phase instanceof CommandPhase) && safety < 100) {
         this.scene.phaseManager.shiftPhase();
+        while (this.scene.phaseManager.hasQueuedShift()) {
+          this.scene.phaseManager.shiftPhase();
+        }
         phase = this.scene.phaseManager.getCurrentPhase();
         safety++;
       }

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -224,6 +224,7 @@ export class PhaseManager {
 
   private currentPhase: Phase | null = null;
   private standbyPhase: Phase | null = null;
+  private shiftPending = false;
 
   /* Phase Functions */
   getCurrentPhase(): Phase | null {
@@ -232,6 +233,14 @@ export class PhaseManager {
 
   getStandbyPhase(): Phase | null {
     return this.standbyPhase;
+  }
+
+  queueShift(): void {
+    this.shiftPending = true;
+  }
+
+  hasQueuedShift(): boolean {
+    return this.shiftPending;
   }
 
   /**
@@ -308,6 +317,7 @@ export class PhaseManager {
    * then removes first Phase and starts it
    */
   shiftPhase(): void {
+    this.shiftPending = false;
     if (this.standbyPhase) {
       this.currentPhase = this.standbyPhase;
       this.standbyPhase = null;

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -5,7 +5,7 @@ export abstract class Phase {
   start() {}
 
   end() {
-    globalScene.phaseManager.shiftPhase();
+    globalScene.phaseManager.queueShift();
   }
 
   /**

--- a/test/rogue-env.test.ts
+++ b/test/rogue-env.test.ts
@@ -388,10 +388,16 @@ describe("rogue-env parity", () => {
       }
     }
     scene.phaseManager.shiftPhase();
+    while (scene.phaseManager.hasQueuedShift()) {
+      scene.phaseManager.shiftPhase();
+    }
     let p = scene.phaseManager.getCurrentPhase();
     let safety = 0;
     while (p && !(p instanceof CommandPhase) && safety < 100) {
       scene.phaseManager.shiftPhase();
+      while (scene.phaseManager.hasQueuedShift()) {
+        scene.phaseManager.shiftPhase();
+      }
       p = scene.phaseManager.getCurrentPhase();
       safety++;
     }
@@ -484,6 +490,9 @@ describe("rogue-env parity", () => {
     scene.phaseManager.clearAllPhases();
     scene.phaseManager.pushNew("TurnInitPhase");
     scene.phaseManager.shiftPhase();
+    while (scene.phaseManager.hasQueuedShift()) {
+      scene.phaseManager.shiftPhase();
+    }
 
     const states = [getState(scene)];
     for (const act of actions) {


### PR DESCRIPTION
## Summary
- prevent deep recursion in phase manager by queueing shifts
- update rogue environment to process queued shifts
- adjust tests for new phase processing

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_684ae1f408448324a7a8dfaa0a8ea287