### PR TITLE
Fix starter movesets in RL helper

### DIFF
--- a/test/testUtils/gameManagerUtils.ts
+++ b/test/testUtils/gameManagerUtils.ts
@@ -53,6 +53,7 @@ export function generateStarter(scene: BattleScene, species?: SpeciesId[]): Star
       undefined,
       starter.nature,
     );
+    starterPokemon.generateAndPopulateMoveset();
     const moveset: MoveId[] = [];
     starterPokemon.moveset.forEach(move => {
       moveset.push(move!.getMove().id);
@@ -127,6 +128,7 @@ export function initSceneWithoutEncounterPhase(scene: BattleScene, species?: Spe
       starterIvs,
       starter.nature,
     );
+    starterPokemon.generateAndPopulateMoveset();
     starter.moveset && starterPokemon.tryPopulateMoveset(starter.moveset);
     scene.getPlayerParty().push(starterPokemon);
   });


### PR DESCRIPTION
## Summary
- generate and capture moves when building starter metadata

## Testing
- `npm run test:silent -- test/rogue-env.test.ts`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 10 my-model my-log.json.gz` *(manually stopped after ~15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_684af78fea8c8324add8f39e51d666f1