### PR TITLE
Fix battle initialization and target selection handling

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -191,9 +191,14 @@ export default class RogueEnv {
     this.scene.resetSeed();
     this.scene.enableTutorials = false;
     this.scene.eggSkipPreference = 2;
-    initSceneWithoutEncounterPhase(this.scene, [SpeciesId.SQUIRTLE, SpeciesId.BULBASAUR, SpeciesId.CHARMANDER]);
-    this.scene.currentBattle.incrementTurn();
+    initSceneWithoutEncounterPhase(this.scene, [
+      SpeciesId.SQUIRTLE,
+      SpeciesId.BULBASAUR,
+      SpeciesId.CHARMANDER,
+    ]);
     this.scene.phaseManager.clearAllPhases();
+    this.scene.newBattle();
+    this.scene.currentBattle.incrementTurn();
     this.scene.phaseManager.pushNew("TurnInitPhase");
     this.scene.phaseManager.shiftPhase();
     while (this.scene.phaseManager.hasQueuedShift()) {
@@ -330,8 +335,21 @@ export default class RogueEnv {
         this.scene.phaseManager.shiftPhase();
       }
       let phase = this.scene.phaseManager.getCurrentPhase();
+      const needsInput = new Set([
+        "SwitchPhase",
+        "SelectTargetPhase",
+        "LearnMovePhase",
+        "SelectModifierPhase",
+        "SelectBiomePhase",
+        "SelectChallengePhase",
+      ]);
       let safety = 0;
-      while (phase && !(phase instanceof CommandPhase) && safety < 100) {
+      while (
+        phase &&
+        !(phase instanceof CommandPhase) &&
+        !needsInput.has(phase.constructor.name) &&
+        safety < 100
+      ) {
         this.scene.phaseManager.shiftPhase();
         while (this.scene.phaseManager.hasQueuedShift()) {
           this.scene.phaseManager.shiftPhase();


### PR DESCRIPTION
## Summary
- ensure battles spawn opponents by calling `newBattle()` during reset
- preserve player input phases in `RogueEnv.step`

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 10 my-model my-log.json.gz` *(manually stopped after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684b12cb65f48324864f167fe8a14634