### PR TITLE
Fix headless battle transitions

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -263,7 +263,19 @@ export default class RogueEnv {
           } else if (action === RogueAction.BAG) {
             phase.handleCommand(Command.BALL, 0);
           } else if (action >= RogueAction.SWITCH_1 && action <= RogueAction.SWITCH_6) {
-            phase.handleCommand(Command.POKEMON, action - RogueAction.SWITCH_1);
+            const slot = action - RogueAction.SWITCH_1;
+            phase.handleCommand(Command.POKEMON, slot);
+            // immediately select the slot when the switch UI appears
+            this.scene.phaseManager.shiftPhase();
+            while (this.scene.phaseManager.hasQueuedShift()) {
+              this.scene.phaseManager.shiftPhase();
+            }
+            const switchPhase: any = this.scene.phaseManager.getCurrentPhase();
+            if (switchPhase?.constructor.name === "SwitchPhase") {
+              const handler: any = this.scene.ui.getHandler();
+              const cb = handler?.selectCallback as ((s: number, o: number) => void) | undefined;
+              cb?.(slot, 1);
+            }
           }
         } else if (phase?.constructor.name === "SelectTargetPhase") {
           const handler: any = this.scene.ui.getHandler();

--- a/src/phases/damage-anim-phase.ts
+++ b/src/phases/damage-anim-phase.ts
@@ -72,9 +72,10 @@ export class DamageAnimPhase extends PokemonPhase {
         repeat: 5,
         startAt: 200,
         callback: () => {
-          this.getPokemon()
-            .getSprite()
-            .setVisible(flashTimer.repeatCount % 2 === 0);
+          const sprite = this.getPokemon()?.getSprite?.();
+          if (sprite) {
+            sprite.setVisible(flashTimer.repeatCount % 2 === 0);
+          }
           if (!flashTimer.repeatCount) {
             this.getPokemon()
               .updateInfo()


### PR DESCRIPTION
## Summary
- avoid sprite errors in `DamageAnimPhase` during headless training
- execute switch commands in `RogueEnv` automatically

## Testing
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 1 10 model-5 log-5.json` *(fails: manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_684c58fa0fac832497b815b935e7137d