### PR TITLE
Fix switch timing

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -225,6 +225,7 @@ export default class RogueEnv {
     while (this.scene.phaseManager.hasQueuedShift()) {
       this.scene.phaseManager.shiftPhase();
     }
+    this.flushTimers();
   }
 
   /**
@@ -232,6 +233,21 @@ export default class RogueEnv {
    */
   terminate(): void {
     this.terminated = true;
+  }
+
+  /**
+   * Flush pending timed events so asynchronous phase callbacks execute
+   * before the next state snapshot is taken.
+   */
+  private flushTimers(iterations = 5): void {
+    const clock: any = this.scene.time as any;
+    for (let i = 0; i < iterations; i++) {
+      clock.preUpdate(clock.systems.game.loop.time, 1);
+      clock.update(clock.systems.game.loop.time, 1);
+      if (!clock._pendingInsertion.length && !clock._active.length) {
+        break;
+      }
+    }
   }
 
   /**
@@ -247,6 +263,7 @@ export default class RogueEnv {
     }
     let total = 0;
     for (let i = 0; i < fastForward; i++) {
+      this.flushTimers();
       const prevState = this.getState();
 
       if (typeof action === "number") {
@@ -357,6 +374,7 @@ export default class RogueEnv {
       while (this.scene.phaseManager.hasQueuedShift()) {
         this.scene.phaseManager.shiftPhase();
       }
+      this.flushTimers();
       let phase = this.scene.phaseManager.getCurrentPhase();
       const needsInput = new Set([
         "SwitchPhase",
@@ -372,6 +390,7 @@ export default class RogueEnv {
         while (this.scene.phaseManager.hasQueuedShift()) {
           this.scene.phaseManager.shiftPhase();
         }
+        this.flushTimers();
         phase = this.scene.phaseManager.getCurrentPhase();
         safety++;
       }
@@ -395,6 +414,8 @@ export default class RogueEnv {
       }
 
       total += stepReward;
+
+      this.flushTimers();
 
       if (this.terminated) {
         break;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -18,6 +18,7 @@ import { getGameMode } from "#app/game-mode";
 import { GameModes } from "#enums/game-modes";
 import { BattleType } from "#enums/battle-type";
 import TrainerData from "#app/system/trainer-data";
+import { headless } from "#app/global-vars/headless";
 import { trainerConfigs } from "#app/data/trainers/trainer-config";
 import { resetSettings, setSetting, SettingKeys } from "#app/system/settings/settings";
 import { achvs } from "#app/system/achv";
@@ -1867,7 +1868,9 @@ export class GameData {
     // Only gain candies if the Pokemon has already been marked as caught in dex (ignore "rental" pokemon)
     const speciesRootForm = species.getRootSpeciesId();
     if (globalScene.gameData.dexData[speciesRootForm].caughtAttr) {
-      globalScene.candyBar.showStarterSpeciesCandy(species.speciesId, count);
+      if (!headless) {
+        globalScene.candyBar.showStarterSpeciesCandy(species.speciesId, count);
+      }
       this.starterData[species.speciesId].candyCount += count;
     }
   }

--- a/test/testUtils/TextInterceptor.ts
+++ b/test/testUtils/TextInterceptor.ts
@@ -19,6 +19,9 @@ export default class TextInterceptor {
   ): void {
     // Suppress console output during headless execution
     this.logs.push(text);
+    if (_callback) {
+      _callback();
+    }
   }
 
   showDialogue(
@@ -31,6 +34,9 @@ export default class TextInterceptor {
   ): void {
     // Suppress console output during headless execution
     this.logs.push(name, text);
+    if (_callback) {
+      _callback();
+    }
   }
 
   getLatestMessage(): string {


### PR DESCRIPTION
## Summary
- flush timed events between steps so delayed callbacks complete
- call text callbacks during headless execution
- avoid CandyBar calls when running headless

## Testing
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json`

------
https://chatgpt.com/codex/tasks/task_e_684c70cf7e6c832490d8592ef798eb1f