### PR TITLE
Adjust reward computation

### DIFF
--- a/REWARDS.md
+++ b/REWARDS.md
@@ -1,0 +1,33 @@
+# Reward Function Overview
+
+The reinforcement learning environment exposes a weighted reward function used by
+`RogueEnv`.  The reward encourages the agent to clear battles while keeping its
+Pokémon healthy and growing the party.
+
+## Current Components
+
+| Component       | Description                                                 |
+|-----------------|-------------------------------------------------------------|
+| `damageDealt`   | Total HP removed from all enemies during a step.           |
+| `hpHealed`      | Amount of HP restored to the player's party.               |
+| `enemyFainted`  | Count of opposing Pokémon that fainted.                    |
+| `playerFainted` | Count of player Pokémon that fainted.                      |
+| `waveCleared`   | Increments when progressing to the next wave **except**
+|                 | when the progress comes from using the `RUN` command.       |
+| `partyLevel`    | Increase in the sum of the player's Pokémon levels.        |
+
+Default weights for these components are defined in `src/env/reward.ts`.
+
+### Planned Component
+
+*Super‑effective Move Chosen* – grant a small bonus whenever the agent selects a
+move that is super‑effective against at least one target in the current turn.
+Implementation will require checking the chosen move's type effectiveness before
+`TurnStartPhase` resolves and adding a positive reward if the move would deal
+super‑effective damage.
+
+## Updating the Reward Function
+
+1. Adjust the weights in `src/env/reward.ts` to tune behaviour.
+2. Run the training script described in `AGENTS.md` and inspect the generated
+   log file to verify that rewards change as expected.

--- a/src/env/reward.ts
+++ b/src/env/reward.ts
@@ -1,17 +1,19 @@
 export interface RewardWeights {
   damageDealt: number;
-  damageTaken: number;
+  hpHealed: number;
   enemyFainted: number;
   playerFainted: number;
   waveCleared: number;
+  partyLevel: number;
 }
 
 export const DEFAULT_WEIGHTS: RewardWeights = {
   damageDealt: 1,
-  damageTaken: -1,
+  hpHealed: 1,
   enemyFainted: 50,
   playerFainted: -50,
   waveCleared: 200,
+  partyLevel: 10,
 };
 
 import type { SerializedState } from "#app/utils/serialize";
@@ -25,15 +27,19 @@ export function getRewardComponents(
   const prevPlayerHp = prev.playerParty.reduce((s, p) => s + p.hp, 0);
   const nextPlayerHp = next.playerParty.reduce((s, p) => s + p.hp, 0);
 
+  const prevPartyLevel = prev.playerParty.reduce((s, p) => s + p.level, 0);
+  const nextPartyLevel = next.playerParty.reduce((s, p) => s + p.level, 0);
+
   const enemyFainted = next.enemyParty.filter((p, i) => p.hp <= 0 && prev.enemyParty[i].hp > 0).length;
   const playerFainted = next.playerParty.filter((p, i) => p.hp <= 0 && prev.playerParty[i].hp > 0).length;
 
   return {
     damageDealt: prevEnemyHp - nextEnemyHp,
-    damageTaken: prevPlayerHp - nextPlayerHp,
+    hpHealed: Math.max(0, nextPlayerHp - prevPlayerHp),
     enemyFainted,
     playerFainted,
     waveCleared: next.wave > prev.wave ? 1 : 0,
+    partyLevel: Math.max(0, nextPartyLevel - prevPartyLevel),
   };
 }
 
@@ -45,9 +51,10 @@ export function computeStepReward(
   const comps = getRewardComponents(prev, next);
   return (
     comps.damageDealt * weights.damageDealt +
-    comps.damageTaken * weights.damageTaken +
+    comps.hpHealed * weights.hpHealed +
     comps.enemyFainted * weights.enemyFainted +
     comps.playerFainted * weights.playerFainted +
-    comps.waveCleared * weights.waveCleared
+    comps.waveCleared * weights.waveCleared +
+    comps.partyLevel * weights.partyLevel
   );
 }

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -7,7 +7,7 @@ import { randomString } from "#app/utils/common";
 import serializeState, { type SerializedState } from "#app/utils/serialize";
 import type TransitionLogger from "#env/transition-logger";
 import type { TransitionRecord } from "#env/transition-logger";
-import { computeStepReward } from "#env/reward";
+import { computeStepReward, DEFAULT_WEIGHTS } from "#env/reward";
 import GameWrapper from "#test/testUtils/gameWrapper";
 import { initSceneWithoutEncounterPhase } from "#test/testUtils/gameManagerUtils";
 import { SpeciesId } from "#enums/species-id";
@@ -399,7 +399,14 @@ export default class RogueEnv {
       if (nextState.phase === "VictoryPhase" || nextState.phase === "GameOverPhase") {
         this.terminated = true;
       }
-      const computed = computeStepReward(prevState, nextState);
+      let computed = computeStepReward(prevState, nextState);
+      if (
+        typeof action === "number" &&
+        action === RogueAction.RUN &&
+        nextState.wave > prevState.wave
+      ) {
+        computed -= DEFAULT_WEIGHTS.waveCleared;
+      }
       const stepReward = reward === undefined ? computed : reward;
 
       if (this.logger) {


### PR DESCRIPTION
## Summary
- track party level gains and HP healed in rewards
- ignore wave reward when fleeing
- document reward structure

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(manually stopped after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684c8124f50483248d227372aea7b899