### PR TITLE
Fix reward calculation for new wave spawns

### DIFF
--- a/src/env/reward.ts
+++ b/src/env/reward.ts
@@ -34,7 +34,10 @@ export function getRewardComponents(
   const playerFainted = next.playerParty.filter((p, i) => p.hp <= 0 && prev.playerParty[i].hp > 0).length;
 
   return {
-    damageDealt: prevEnemyHp - nextEnemyHp,
+    damageDealt:
+      next.wave > prev.wave
+        ? prevEnemyHp
+        : prevEnemyHp - nextEnemyHp,
     hpHealed: Math.max(0, nextPlayerHp - prevPlayerHp),
     enemyFainted,
     playerFainted,


### PR DESCRIPTION
## Summary
- correct damage reward when a new enemy wave spawns

## Testing
- `bash setup.sh`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(manually stopped after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684c8be67cdc8324856b0b205e19d2dd