### PR TITLE
Add notes on fixing reward artifacts

### DIFF
--- a/REWARDS.md
+++ b/REWARDS.md
@@ -31,3 +31,19 @@ super‑effective damage.
 1. Adjust the weights in `src/env/reward.ts` to tune behaviour.
 2. Run the training script described in `AGENTS.md` and inspect the generated
    log file to verify that rewards change as expected.
+
+## Eliminating Wave Transition Artifacts
+
+`getRewardComponents` currently rewards raw differences in enemy HP. When a new wave spawns with higher HP than the old one, this causes negative `damageDealt` even though the agent did nothing. Likewise, using `RUN` advances the wave and yields a bonus equal to the previous enemies' HP.
+
+To fix these issues:
+
+1. Clamp the `damageDealt` calculation so HP increases never become negative and only count actual damage. Around lines 36‑45 of `src/env/reward.ts`, compute:
+   ```ts
+   const diff = prevEnemyHp - nextEnemyHp;
+   const damageDealt = next.wave === prev.wave && diff > 0 ? diff : 0;
+   ```
+   This ignores enemy healing or newly spawned Pokémon.
+2. When a wave changes because of the `RUN` command, also remove the damage bonus that `getRewardComponents` adds. In `RogueEnv.runEpisode` (lines 402‑409 of `src/env/rogue-env.ts`), subtract `prevEnemyHp` from the computed reward whenever `RUN` progresses the wave.
+
+These adjustments ensure rewards only reflect real damage inflicted and prevent fleeing from giving unintended positives.


### PR DESCRIPTION
## Summary
- document how to adjust `damageDealt` and running bonuses

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(manually stopped)*

------
https://chatgpt.com/codex/tasks/task_e_684c8e36337c832499b2e12a8bc26add