### PR TITLE
Fix reward calculation for new wave transitions

### DIFF
--- a/src/env/reward.ts
+++ b/src/env/reward.ts
@@ -24,6 +24,7 @@ export function getRewardComponents(
 ) {
   const prevEnemyHp = prev.enemyParty.reduce((s, p) => s + p.hp, 0);
   const nextEnemyHp = next.enemyParty.reduce((s, p) => s + p.hp, 0);
+  const diff = prevEnemyHp - nextEnemyHp;
   const prevPlayerHp = prev.playerParty.reduce((s, p) => s + p.hp, 0);
   const nextPlayerHp = next.playerParty.reduce((s, p) => s + p.hp, 0);
 
@@ -35,9 +36,7 @@ export function getRewardComponents(
 
   return {
     damageDealt:
-      next.wave > prev.wave
-        ? prevEnemyHp
-        : prevEnemyHp - nextEnemyHp,
+      next.wave === prev.wave && diff > 0 ? diff : 0,
     hpHealed: Math.max(0, nextPlayerHp - prevPlayerHp),
     enemyFainted,
     playerFainted,

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -405,7 +405,8 @@ export default class RogueEnv {
         action === RogueAction.RUN &&
         nextState.wave > prevState.wave
       ) {
-        computed -= DEFAULT_WEIGHTS.waveCleared;
+        const prevEnemyHp = prevState.enemyParty.reduce((s, p) => s + p.hp, 0);
+        computed -= prevEnemyHp * DEFAULT_WEIGHTS.damageDealt;
       }
       const stepReward = reward === undefined ? computed : reward;
 


### PR DESCRIPTION
## Summary
- ignore enemy HP change when a new wave spawns
- remove bonus damage when the RUN command changes the wave

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(manually stopped after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684c98bd0f3083248d109e2532d88b0e