### PR TITLE
Enable money accumulation in headless env

### DIFF
--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -137,7 +137,10 @@ export default class RogueEnv {
   /** Base seed used to initialize each run. */
   private seed: string;
 
-  constructor(seed?: string) {
+  constructor(
+    seed?: string,
+    private startingMoney = 0,
+  ) {
     this.seed = seed ?? randomString(24);
     // Minimal data initialization mimicking the test setup
     initAbilities();
@@ -188,6 +191,7 @@ export default class RogueEnv {
     this.terminated = false;
     this.seed = seed;
     this.scene.reset(false, true);
+    this.scene.money = this.startingMoney;
     this.scene.setSeed(this.seed);
     this.scene.resetSeed();
     this.scene.enableTutorials = false;
@@ -400,13 +404,12 @@ export default class RogueEnv {
         this.terminated = true;
       }
       let computed = computeStepReward(prevState, nextState);
-      if (
-        typeof action === "number" &&
-        action === RogueAction.RUN &&
-        nextState.wave > prevState.wave
-      ) {
+      if (typeof action === "number" && action === RogueAction.RUN && nextState.wave > prevState.wave) {
         const prevEnemyHp = prevState.enemyParty.reduce((s, p) => s + p.hp, 0);
         computed -= prevEnemyHp * DEFAULT_WEIGHTS.damageDealt;
+      }
+      if (nextState.wave > prevState.wave && !(typeof action === "number" && action === RogueAction.RUN)) {
+        this.scene.addMoney(this.scene.getWaveMoneyAmount(nextState.wave - prevState.wave));
       }
       const stepReward = reward === undefined ? computed : reward;
 


### PR DESCRIPTION
## Summary
- add `startingMoney` option to `RogueEnv`
- give starting money when resetting the scene
- award wave money whenever the wave counter increases, unless the player chose to run

## Testing
- `npx biome format --write src/env/rogue-env.ts`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684ca2fc9d6c83249dd817d512d65c3e