### PR TITLE
Enhance shop awareness in DQN state

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -10,16 +10,39 @@ function flattenState(state: SerializedState): number[] {
     if (idx === undefined || idx < 0 || idx >= party.length) return undefined;
     return party[idx];
   };
+
   const player = getMon(state.playerParty, state.playerActive);
   const enemy = getMon(state.enemyParty, state.enemyActive);
   const playerHp = player ? player.hp / player.maxHp : 0;
   const enemyHp = enemy ? enemy.hp / enemy.maxHp : 0;
   const playerLevel = player?.level ?? 0;
   const enemyLevel = enemy?.level ?? 0;
-  return [state.turn, state.wave, playerHp, enemyHp, playerLevel, enemyLevel];
+
+  const isShop = state.phase === "SelectModifierPhase" ? 1 : 0;
+  const money = (state.money ?? 0) / 1000;
+  const shopCosts = (state.shopOptions ?? [])
+    .slice(0, 3)
+    .map(o => o.cost / 1000);
+  while (shopCosts.length < 3) shopCosts.push(0);
+  const cursor = (state.shopCursor ?? 0) / 10;
+  const rowCursor = (state.shopRowCursor ?? 0) / 10;
+
+  return [
+    state.turn,
+    state.wave,
+    playerHp,
+    enemyHp,
+    playerLevel,
+    enemyLevel,
+    isShop,
+    money,
+    ...shopCosts,
+    cursor,
+    rowCursor,
+  ];
 }
 
-const INPUT_SIZE = 6;
+const INPUT_SIZE = 13;
 const ACTION_COUNT = 42; // total actions in RogueAction enum
 
 class DQNAgent {

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -409,7 +409,7 @@ export default class RogueEnv {
         computed -= prevEnemyHp * DEFAULT_WEIGHTS.damageDealt;
       }
       if (prevState.phase === "SelectModifierPhase" && nextState.money < prevState.money) {
-        computed += 5;
+        computed += 10;
       }
       if (nextState.wave > prevState.wave && !(typeof action === "number" && action === RogueAction.RUN)) {
         this.scene.addMoney(this.scene.getWaveMoneyAmount(nextState.wave - prevState.wave));

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -611,6 +611,10 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     return false;
   }
 
+  getRowCursor(): number {
+    return this.rowCursor;
+  }
+
   private getRowItems(rowCursor: number): number {
     switch (rowCursor) {
       case 0:

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -8,6 +8,7 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { getPlayerShopModifierTypeOptionsForWave } from "#app/modifier/modifier-type";
 import { HealShopCostModifier } from "#app/modifier/modifier";
+import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { NumberHolder } from "#app/utils/common";
 
 /** Current version of the serialized state schema. */
@@ -79,6 +80,10 @@ export interface SerializedState {
   enemyModifiers: { id: string; stack: number }[];
   /** Current shop options when available. */
   shopOptions?: { id: string; cost: number }[];
+  /** Cursor index within the current shop row when available. */
+  shopCursor?: number;
+  /** Selected shop row index when available. */
+  shopRowCursor?: number;
 }
 
 function serializePokemon(p: Pokemon): SerializedPokemon {
@@ -107,11 +112,16 @@ function serializePokemon(p: Pokemon): SerializedPokemon {
 export default function serializeState(scene: BattleScene): SerializedState {
   const phaseName = scene.phaseManager.getCurrentPhase()?.constructor.name;
   let shopOptions: { id: string; cost: number }[] | undefined;
+  let shopCursor: number | undefined;
+  let shopRowCursor: number | undefined;
   if (phaseName === "SelectModifierPhase" && !scene.gameMode.hasNoShop) {
     const baseCost = scene.getWaveMoneyAmount(1);
     const holder = new NumberHolder(baseCost);
     scene.applyModifier(HealShopCostModifier, true, holder);
     shopOptions = getPlayerShopModifierTypeOptionsForWave(scene.currentBattle.waveIndex, holder.value).map(o => ({ id: o.type.id, cost: o.cost }));
+    const handler = scene.ui.getHandler<ModifierSelectUiHandler>();
+    shopCursor = handler.getCursor();
+    shopRowCursor = handler.getRowCursor();
   }
   return {
     schemaVersion: STATE_SCHEMA_VERSION,
@@ -140,5 +150,7 @@ export default function serializeState(scene: BattleScene): SerializedState {
     playerModifiers: scene.modifiers.map(m => ({ id: m.type.id, stack: m.stackCount })),
     enemyModifiers: scene.enemyModifiers.map(m => ({ id: m.type.id, stack: m.stackCount })),
     shopOptions,
+    shopCursor,
+    shopRowCursor,
   };
 }


### PR DESCRIPTION
## Summary
- expose the shop UI cursor in `ModifierSelectUiHandler`
- serialize cursor positions in `serializeState`
- feed cursor data into the DQN state and adjust input size

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(interrupted after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684cbb65ff2c83249ff0ce980661593a