### PR TITLE
Fix training crashes at longer episodes

### DIFF
--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -13,7 +13,7 @@ export class CheckStatusEffectPhase extends Phase {
   start() {
     const field = globalScene.getField();
     for (const o of this.order) {
-      if (field[o].status?.isPostTurn()) {
+      if (field[o]?.status?.isPostTurn()) {
         globalScene.phaseManager.unshiftNew("PostTurnStatusEffectPhase", o);
       }
     }

--- a/src/phases/pokemon-phase.ts
+++ b/src/phases/pokemon-phase.ts
@@ -11,14 +11,14 @@ export abstract class PokemonPhase extends FieldPhase {
   constructor(battlerIndex?: BattlerIndex | number) {
     super();
 
-    battlerIndex =
-      battlerIndex ??
-      globalScene
-        .getField()
-        .find(p => p?.isActive())! // TODO: is the bang correct here?
-        .getBattlerIndex();
     if (battlerIndex === undefined) {
-      console.warn("There are no Pokemon on the field!"); // TODO: figure out a suitable fallback behavior
+      const defaultPokemon = globalScene.getField().find(p => p?.isActive());
+      if (defaultPokemon) {
+        battlerIndex = defaultPokemon.getBattlerIndex();
+      } else {
+        console.warn("There are no Pokemon on the field!");
+        battlerIndex = BattlerIndex.PLAYER;
+      }
     }
 
     this.battlerIndex = battlerIndex;


### PR DESCRIPTION
## Summary
- handle null field entries in `CheckStatusEffectPhase`
- provide safe fallback in `PokemonPhase` constructor

## Testing
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` (terminated after ~15s)

------
https://chatgpt.com/codex/tasks/task_e_684cd14a626c8324a0a163190c0f098a