### PR TITLE
Fix RL crashes when field slots are empty

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -155,6 +155,16 @@ class DQNAgent {
     let state = flattenState(env.getState());
     for (let t = 0; t < maxSteps && !env.terminated && !interrupted; t++) {
       const available = env.getAvailableActions();
+      if (available.length === 0) {
+        const snapshot = env.getState();
+        const usable = snapshot.playerParty.some(p => p.hp > 0);
+        if (!usable) {
+          break;
+        }
+        env.step();
+        state = flattenState(env.getState());
+        continue;
+      }
       const action = agent.act(state, available);
       const reward = env.step(action as RogueAction);
       const nextState = flattenState(env.getState());

--- a/src/env/rogue-env.ts
+++ b/src/env/rogue-env.ts
@@ -300,7 +300,7 @@ export default class RogueEnv {
    * Flush pending timed events so asynchronous phase callbacks execute
    * before the next state snapshot is taken.
    */
-  private flushTimers(iterations = 5): void {
+  private flushTimers(iterations = 10): void {
     const clock: any = this.scene.time as any;
     for (let i = 0; i < iterations; i++) {
       clock.preUpdate(clock.systems.game.loop.time, 1);

--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -13,7 +13,8 @@ export class CheckStatusEffectPhase extends Phase {
   start() {
     const field = globalScene.getField();
     for (const o of this.order) {
-      if (field[o].status?.isPostTurn()) {
+      const pokemon = field[o] as any;
+      if (pokemon?.status?.isPostTurn()) {
         globalScene.phaseManager.unshiftNew("PostTurnStatusEffectPhase", o);
       }
     }

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -11,7 +11,13 @@ export class PostSummonPhase extends PokemonPhase {
   start() {
     super.start();
 
-    const pokemon = this.getPokemon();
+    const pokemon = this.getPokemon() as any;
+    if (!pokemon) {
+      if (globalScene.getPokemonAllowedInBattle().length === 0) {
+        globalScene.phaseManager.unshiftNew("GameOverPhase");
+      }
+      return this.end();
+    }
 
     if (pokemon.status?.effect === StatusEffect.TOXIC) {
       pokemon.status.toxicTurnCount = 0;


### PR DESCRIPTION
## Summary
- guard against undefined Pokémon in `PostSummonPhase` and `CheckStatusEffectPhase`
- increase timer flush iterations to avoid async race conditions
- check for missing actions during RL training and break when no usable Pokémon remain

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 3 10 model-5 log-5.json` *(stopped after ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_684cd883e5f88324986ee21cbc8da356