### PR TITLE
Ensure training script exits cleanly

### DIFF
--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -167,8 +167,9 @@ class DQNAgent {
 
   if (!interrupted) {
     await saveProgress();
+    process.exit(0);
   }
-  }
+}
 
 const episodes = Number.parseInt(process.argv[2] ?? process.env.ROGUE_EPISODES ?? "10", 10);
 const maxSteps = Number.parseInt(process.argv[3] ?? process.env.ROGUE_MAX_STEPS ?? "200", 10);


### PR DESCRIPTION
## Summary
- update DQN training script to exit Node after saving progress

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 2 20 model-5 log-5.json`

------
https://chatgpt.com/codex/tasks/task_e_684cdba5444c832486803ced65b47bbb