### PR TITLE
Handle no remaining Pokémon after faint

### DIFF
--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -13,7 +13,8 @@ export class CheckStatusEffectPhase extends Phase {
   start() {
     const field = globalScene.getField();
     for (const o of this.order) {
-      if (field[o].status?.isPostTurn()) {
+      const pokemon = field[o];
+      if (pokemon && pokemon.status?.isPostTurn()) {
         globalScene.phaseManager.unshiftNew("PostTurnStatusEffectPhase", o);
       }
     }

--- a/src/phases/pokemon-phase.ts
+++ b/src/phases/pokemon-phase.ts
@@ -26,10 +26,10 @@ export abstract class PokemonPhase extends FieldPhase {
     this.fieldIndex = battlerIndex % 2;
   }
 
-  getPokemon(): Pokemon {
+  getPokemon(): Pokemon | undefined {
     if (this.battlerIndex > BattlerIndex.ENEMY_2) {
-      return globalScene.getPokemonById(this.battlerIndex)!; //TODO: is this bang correct?
+      return globalScene.getPokemonById(this.battlerIndex);
     }
-    return globalScene.getField()[this.battlerIndex]!; //TODO: is this bang correct?
+    return globalScene.getField()[this.battlerIndex];
   }
 }

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -12,6 +12,10 @@ export class PostSummonPhase extends PokemonPhase {
     super.start();
 
     const pokemon = this.getPokemon();
+    if (!pokemon) {
+      this.end();
+      return;
+    }
 
     if (pokemon.status?.effect === StatusEffect.TOXIC) {
       pokemon.status.toxicTurnCount = 0;

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -26,7 +26,11 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
 
   start() {
     const pokemon = this.getPokemon();
-    if (pokemon?.isActive(true) && pokemon.status && pokemon.status.isPostTurn() && !pokemon.switchOutStatus) {
+    if (!pokemon) {
+      this.end();
+      return;
+    }
+    if (pokemon.isActive(true) && pokemon.status && pokemon.status.isPostTurn() && !pokemon.switchOutStatus) {
       pokemon.status.incrementTurn();
       const cancelled = new BooleanHolder(false);
       applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
@@ -65,8 +69,9 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
   }
 
   override end() {
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
-      globalScene.initFinalBossPhaseTwo(this.getPokemon());
+    const pokemon = this.getPokemon();
+    if (pokemon && globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+      globalScene.initFinalBossPhaseTwo(pokemon);
     } else {
       super.end();
     }


### PR DESCRIPTION
## Summary
- ensure `PokemonPhase.getPokemon` returns `undefined` when no Pokémon is on the field
- guard against undefined Pokémon in PostSummonPhase, CheckStatusEffectPhase and PostTurnStatusEffectPhase

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 1 20 model-5 log-5.json`

------
https://chatgpt.com/codex/tasks/task_e_684ce0caebf083248b8c8eb401741a9b