### PR TITLE
Improve training script saving and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 50 500 my-model my-log.json.gz
 Environment variables `ROGUE_EPISODES`, `ROGUE_MAX_STEPS`, `ROGUE_MODEL_PATH` and `ROGUE_LOG_PATH` may be used instead of arguments.
 If the log filename ends with `.gz` it will be gzip compressed.
 
+When stopping training manually, send `SIGINT` to the entire process group so the
+interrupt handler can save the model and log:
+
+```bash
+kill -SIGINT -<pgid>
+```
+
 
 
 ## 🪧 To Do

--- a/docs/rl-guide.md
+++ b/docs/rl-guide.md
@@ -33,6 +33,13 @@ VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 50 500 my-model my-log.json.gz
 Environment variables `ROGUE_EPISODES`, `ROGUE_MAX_STEPS`, `ROGUE_MODEL_PATH` and
 `ROGUE_LOG_PATH` may also be provided.
 
+When terminating training manually, send `SIGINT` to the entire process group so
+the interrupt handler can persist the model and log. On Linux you can use:
+
+```bash
+kill -SIGINT -<pgid>
+```
+
 The model directory defaults to `dqn-model`. When a log path is supplied the
 training transitions are saved (gzip compressed if the filename ends with `.gz`).
 

--- a/scripts/rogue-env-dqn.ts
+++ b/scripts/rogue-env-dqn.ts
@@ -161,7 +161,11 @@ class DQNAgent {
       agent.remember(state, action, reward, nextState, env.terminated);
       state = nextState;
       await agent.replay();
+      if ((t + 1) % 10 === 0) {
+        await saveProgress();
+      }
     }
+    await saveProgress();
     console.log(`Episode ${ep + 1} complete`);
   }
 


### PR DESCRIPTION
## Summary
- ensure `rogue-env-dqn.ts` saves progress every 10 steps and after each episode
- document how to stop training safely

## Testing
- `bash setup.sh`
- `source ~/.nvm/nvm.sh && nvm use 22.14.0`
- `npm rebuild @tensorflow/tfjs-node --build-addon-from-source`
- `bash verify-setup.sh`
- `ROGUE_SEED=4 VITE_HEADLESS=1 npx tsx scripts/rogue-env-dqn.ts 1 10 model-5 log-5.json`

------
https://chatgpt.com/codex/tasks/task_e_684cecad5bbc8324b2985ab06bb79eec